### PR TITLE
chore: enabledPlugins の Notion 大小重複を解消 (#13)

### DIFF
--- a/config/.claude/settings.json
+++ b/config/.claude/settings.json
@@ -70,7 +70,6 @@
     "qodo-skills@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
     "notion@claude-plugins-official": true,
-    "Notion@claude-plugins-official": false,
     "chrome-devtools-mcp@claude-plugins-official": true
   },
   "language": "Japanese",


### PR DESCRIPTION
## Summary

- `config/.claude/settings.json` の `enabledPlugins` から、大小違いで重複していた `Notion@claude-plugins-official: false` を 1 行削除
- 現行の `notion@claude-plugins-official: true` のみを残し、プラグイン CLI 旧表記の残骸を除去

## Context

`/plugins` の過去バージョンで `Notion`、現行で `notion` という表記ゆれが残った状態。`false` 側は動いておらず実害はないが、レビュー・`git blame` 時のノイズになるため掃除する。skill-audit (#10) 連番の 1 件。

## Out of scope

- `settings.json:21` の `mcp__plugin_Notion_notion` (permissions.allow) は MCP ツール prefix の別レイヤーで、今回は触らない
- `Brewfile` / `flake.nix` の `notion` は Homebrew Cask で無関係

## Test plan

- [x] JSON 妥当性確認 (`python3 -m json.tool` 成功)
- [ ] Claude Code 再起動後に `/plugins` で `notion@claude-plugins-official` が enabled のまま、`Notion@...` が表示されないことを確認
- [ ] Notion MCP ツール (`mcp__plugin_Notion_notion` 系) が従来通り動作することを確認

Closes #13