### PR TITLE
feat: takt のグローバル設定を nix-darwin で管理

### DIFF
--- a/config/.takt/config.yaml
+++ b/config/.takt/config.yaml
@@ -1,0 +1,7 @@
+# takt グローバル設定
+#
+# プロバイダ・モデル・言語を全プロジェクト共通で定義する。
+# プロジェクト固有のオーバーライドは各リポジトリの .takt/config.yaml で行う。
+
+provider: claude
+language: ja

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -115,5 +115,9 @@ in
     link_force "${dotfilesDir}/.claude/statusline-command.sh" "$HOME/.claude/statusline-command.sh"
     link_force "${dotfilesDir}/.claude/hooks" "$HOME/.claude/hooks"
     link_force "${dotfilesDir}/.claude/skills" "$HOME/.claude/skills"
+
+    # takt
+    mkdir -p "$HOME/.takt"
+    link_force "${dotfilesDir}/.takt/config.yaml" "$HOME/.takt/config.yaml"
   '';
 }


### PR DESCRIPTION
## 概要

[specv#78](https://github.com/daiki-beppu/specv/pull/78) で導入した takt のグローバル設定 `~/.takt/config.yaml` を `~/.claude/` と同じパターン（`home.activation.linkDotfiles` の `link_force`）でシンボリックリンク管理する。

## 設計判断

- **`~/.takt/` 自体ではなく `~/.takt/config.yaml` をリンク** — `~/.claude/` と同じ「ファイル単位リンク」方式。実体ディレクトリは takt 自身の runtime 用に残す
- **グローバルには `provider` と `language` だけ定義** — モデルや provider_options はプロジェクトごとの色が出やすいので各リポジトリの `.takt/config.yaml` に委ねる
- **flake.nix への takt パッケージ追加は見送り** — takt は bun スクリプト配布で nixpkgs 未収録、現状の `~/.bun/bin/takt` を引き続き利用

## 変更内容

| ファイル | 種別 | 概要 |
|---------|------|------|
| `config/.takt/config.yaml` | 新規 | `provider: claude` / `language: ja` |
| `nix/packages.nix` | 編集 | `home.activation.linkDotfiles` に `~/.takt/config.yaml` のリンク定義追加 |

## テスト計画

- [x] `nix flake check` 通過
- [ ] マージ後にユーザーが `darwin-rebuild switch --flake .` を実行
- [ ] `readlink ~/.takt/config.yaml` が `/Users/mba/01-dev/dotfiles/config/.takt/config.yaml` を指すこと
- [ ] `takt prompt default`（specv リポジトリで実行）の `[INFO] Language: ja` 表示で日本語環境が反映されたこと

## 関連 PR

- specv 側: https://github.com/daiki-beppu/specv/pull/78