### PR TITLE
docs(takt): SKILL.md に persona_providers セクションを追加

### DIFF
--- a/config/.claude/skills/takt/SKILL.md
+++ b/config/.claude/skills/takt/SKILL.md
@@ -216,6 +216,39 @@ language: ja         # 出力言語
 draft_pr: false      # auto-PR 作成時に draft にするか
 ```
 
+### Persona ごとの provider 切替（`persona_providers`）
+
+persona 単位で provider / model / provider_options を上書きするブロック。グローバル設定
+（`~/.takt/config.yaml`）またはプロジェクト設定（`.takt/config.yaml`）に宣言する。
+
+```yaml
+persona_providers:
+  requirements-reviewer:
+    provider: codex
+  testing-reviewer:
+    provider: codex
+  ai-antipattern-reviewer:
+    provider: codex
+  architecture-reviewer:
+    provider: codex
+```
+
+- キーは YAML 上はスネークケース（`persona_providers` / `provider_options`）で書くが、
+  takt 内部では camelCase に正規化される
+- persona 単位で上書きできるフィールドは `provider` / `model` / `provider_options`
+- 上の例は reviewer 系 4 persona（requirements / testing / ai-antipattern / architecture）
+  を Codex に振る運用構成。Claude Code Max のトークン枠を温存しつつレビュー品質を担保する狙い
+
+provider の解決優先順は以下（上が優先）。
+
+1. CLI flag（`--provider`）
+2. `persona_providers.<persona>.provider`
+3. workflow YAML の `step.provider`
+4. プロジェクト設定（`.takt/config.yaml` の `provider`）
+5. グローバル設定（`~/.takt/config.yaml` の `provider`）
+
+step 単位の `provider:` 切替（workflow YAML 側の宣言）は本 skill の範囲外。
+
 ### タスク状態（`.takt/tasks.yaml`）
 
 `takt add` で追記、`takt run` で消化される。


### PR DESCRIPTION
## Summary

- `config/.claude/skills/takt/SKILL.md` に `persona_providers` の使い方セクションを 33 行追加 (Closes #26)
- takt の reviewer-on-Codex 切替パターンの設定例とプロバイダ解決優先順 (CLI flag > persona_providers > step.provider > project config > global config) を明記
- 今後 persona 単位の provider 振り分けを増減するときの参照先になる

## PoC 結果 (本 PR のドッグフーディング)

この PR 自体が `~/.takt/config.yaml` の `persona_providers` 設定を試す PoC として `default-mini` workflow で生成された。logs/`20260519-204009-p86fhs.jsonl` の `step_start` イベントから確認できた provider 割り当て:

| step | persona | provider |
|---|---|---|
| plan | planner | claude |
| implement | coder | claude |
| ai_review (×2) | ai-antipattern-reviewer | **codex** ✓ |
| ai_fix | coder | claude |
| reviewers (parallel: arch-review / supervise) | reviewers | claude (親) |
| finalize_pr | coder | claude |

`ai-antipattern-reviewer` persona が `~/.takt/config.yaml` の `persona_providers` 設定通り **codex で 2 回起動** され、想定通りの動作を確認。実装系 (`coder` / `planner`) と全体判定 (`supervisor`) は Claude のまま、Claude Code Max のトークン枠を温存できている。

実行時間: 24m 14s / 7 iterations。

## Test plan

- [x] `~/.takt/config.yaml` の `persona_providers` が parse される (`takt list --non-interactive`)
- [x] `default-mini` workflow が完走 (`status: completed`)
- [x] `ai-antipattern-reviewer` が codex provider で起動 (logs 確認)
- [x] worktree に SKILL.md +33 行が auto-commit (6e7da33)
- [x] flake metadata 検証 pass (finalize_pr step による)
- [ ] このセクションの内容が `~/.claude/skills/takt/SKILL.md` 経由でリファレンス参照可能になる (merge 後反映確認)

## 関連スコープ外 (別 issue 候補)

- `finalize_pr` instruction が「commit/push/PR は takt 側に委譲」と判断した結果、auto-pr=n の場合に PR が自動生成されない挙動 → takt 本体 or finalize-pr.md instruction の調整余地あり (この PR では手動で作成)

🤖 Generated with [Claude Code](https://claude.com/claude-code) + [Codex](https://openai.com/codex/) (reviewer 系)