### PR TITLE
fix(zsh): NPM_TOKEN 取得失敗時を fail fast 化

### DIFF
--- a/config/.zshrc
+++ b/config/.zshrc
@@ -41,17 +41,29 @@ precmd() {
 }
 
 # NPM_TOKEN lazy loading (1Password CLI)
-# op read はコストが高いため、npm 系コマンド初回実行時にのみ取得する
+# op read はコストが高いため、npm 系コマンド初回実行時にのみ取得する。
+# 取得済みなら以降は何もしない（セッション中の op 問い合わせは成功後 1 回だけ）。
+# 取得失敗時は素の 1Password エラーを握りつぶさず、短い案内に置き換えて中断する
+# （fail fast）。NPM_TOKEN は設定されないため、1Password 復旧後の再実行で再取得する。
 _ensure_npm_token() {
-  if [[ -z "$NPM_TOKEN" ]]; then
-    export NPM_TOKEN="$(op read "op://Personal/npm token/credential")"
+  [[ -n "$NPM_TOKEN" ]] && return 0
+  if ! command -v op >/dev/null 2>&1; then
+    print -u2 "error: op (1Password CLI) が見つかりません"
+    return 1
   fi
+  local token
+  if ! token=$(op read "op://Personal/npm token/credential" 2>/dev/null); then
+    print -u2 "error: 1Password から npm token を取得できません。"
+    print -u2 "  1Password アプリを起動・アンロックしてください"
+    return 1
+  fi
+  export NPM_TOKEN="$token"
 }
 
 for _cmd in ni nr nlx nu nun nci npm npx bun bunx; do
   eval "
     ${_cmd}() {
-      _ensure_npm_token
+      _ensure_npm_token || return \$?
       command ${_cmd} \"\$@\"
     }
   "


### PR DESCRIPTION
## 背景

1Password が自動アップデート（8.12.21）された際にデスクトップ CLI 連携が一時的に切れ、`op read` が失敗。その結果 `bunx`/`npm`/`bun` 実行時に素の 1Password エラー（長文4行）が垂れ流され、原因が分かりにくい状態になっていた。

旧実装は `op read` の失敗を考慮しておらず、失敗しても `NPM_TOKEN` が空のまま処理が進んでいた。

## 変更

`config/.zshrc` の `_ensure_npm_token` を見直し、**fail fast** 化:

- 取得済みなら即 `return 0`（成功後はセッション中 `op` を再問い合わせしない）
- `op` 不在・取得失敗時は **stderr に短い案内**を出して `return 1`（素のエラーは握りつぶさず置き換え）
- ラッパーを `_ensure_npm_token || return $?` にし、取得失敗時はコマンド自体を実行しない

`NPM_TOKEN` は失敗時に設定しないため、1Password 復旧後の再実行で自動的に再取得される。

## 失敗時の表示

\`\`\`
$ bunx specv@latest
error: 1Password から npm token を取得できません。
  1Password アプリを起動・アンロックしてください
# → bunx は実行されず即終了 (exit 1)
\`\`\`

## テスト

`zsh -n` 構文チェック + 関数の3ケース（取得済み / op成功 / op失敗）を手動確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)