### PR TITLE
chore(claude): 有効プラグインを整理

### DIFF
--- a/config/.claude/settings.json
+++ b/config/.claude/settings.json
@@ -32,6 +32,7 @@
       "/Users/mba/01-dev/dotfiles"
     ]
   },
+  "model": "claude-opus-4-7[1m]",
   "hooks": {
     "SessionStart": [
       {
@@ -51,29 +52,15 @@
     "command": "bash ~/.claude/statusline-command.sh"
   },
   "enabledPlugins": {
-    "example-skills@anthropic-agent-skills": false,
     "context7@claude-plugins-official": true,
-    "typescript-lsp@claude-plugins-official": false,
-    "superpowers@claude-plugins-official": false,
-    "frontend-design@claude-plugins-official": false,
-    "code-review@claude-plugins-official": false,
-    "feature-dev@claude-plugins-official": false,
-    "playwright@claude-plugins-official": false,
-    "code-simplifier@claude-plugins-official": false,
-    "supabase@claude-plugins-official": false,
-    "document-skills@anthropic-agent-skills": false,
-    "learning-output-style@claude-plugins-official": false,
+    "typescript-lsp@claude-plugins-official": true,
+    "learning-output-style@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": false,
-    "pr-review-toolkit@claude-plugins-official": false,
-    "explanatory-output-style@claude-plugins-official": false,
-    "vercel@claude-plugins-official": false,
-    "claude-md-management@claude-plugins-official": true,
-    "qodo-skills@claude-plugins-official": true,
+    "qodo-skills@claude-plugins-official": false,
     "skill-creator@claude-plugins-official": true,
-    "notion@claude-plugins-official": true,
+    "notion@claude-plugins-official": false,
     "chrome-devtools-mcp@claude-plugins-official": true,
     "claude-code-setup@claude-plugins-official": true,
-    "codex@openai-codex": true,
     "commit-commands@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
@@ -84,7 +71,6 @@
       }
     }
   },
-  "model": "claude-opus-4-7[1m]",
   "language": "Japanese",
   "voice": {
     "enabled": true,


### PR DESCRIPTION
## Summary
- `enabledPlugins` から未使用プラグインの無効化エントリを削除して簡潔化
- `typescript-lsp` / `learning-output-style` を有効化、`qodo-skills` / `notion` を無効化
- `codex@openai-codex` エントリを除去
- `model`（claude-opus-4-7）定義を設定上部へ移動

🤖 Generated with [Claude Code](https://claude.com/claude-code)