### PR TITLE
chore(claude): status line を 1 分ごとにリフレッシュ

### DIFF
--- a/config/.claude/settings.json
+++ b/config/.claude/settings.json
@@ -49,7 +49,8 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "bash ~/.claude/statusline-command.sh"
+    "command": "bash ~/.claude/statusline-command.sh",
+    "refreshInterval": 60
   },
   "enabledPlugins": {
     "context7@claude-plugins-official": true,


### PR DESCRIPTION
## Summary
- `statusLine.refreshInterval: 60` を追加し、入力待機中も status line が 60 秒ごとに更新されるようにした
- 従来は AI のターン終了時のみ更新だったため、別セッションが起こした git 変更やレートリミット枠の回復が反映されなかった

## Test plan
- [ ] Claude Code を再起動して新セッションを開く
- [ ] 入力せず 1 分以上放置し、status line の表示要素が更新タイミングを刻むことを目視確認
- [ ] 別ターミナルで edit + `git add` し、ターンを発生させずに diff 統計が 60 秒以内に追従することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)