### PR TITLE
takt-review: fix ループを廃止し read-only レビューに変更

### DIFF
--- a/config/.claude/skills/issue-direct/SKILL.md
+++ b/config/.claude/skills/issue-direct/SKILL.md
@@ -103,7 +103,7 @@ EOF
 
 - **exit 0**(全 green) → Step 6 へ
 - **exit ≠ 0** → `gh pr checks <PR#>` で失敗 check を特定し、`gh run view <run-id> --log-failed` で失敗ログを取得
-  - worktree 内で修正する。指摘行だけを直さず「症状 → 根本原因 → 同型箇所 → 修正 → 検証」に分解してから直す(takt-review の fix プラクティスを踏襲)
+  - worktree 内で修正する。指摘行だけを直さず「症状 → 根本原因 → 同型箇所 → 修正 → 検証」に分解してから直す
   - commit → push → Step 4 を再実行、ラウンド +1
   - **3 周を超えたら**ユーザーに状況を報告し人手判断を仰ぐ(自動で回し続けない)
   - CI fail が対象 issue のスコープ外(flaky test 等)と判断した場合もユーザーに報告し判断を仰ぐ

--- a/config/.claude/skills/takt-issue/SKILL.md
+++ b/config/.claude/skills/takt-issue/SKILL.md
@@ -433,7 +433,7 @@ Claude Code では `Bash` の `run_in_background: true` で投げる（timeout `
 - **exit ≠ 0** → 失敗 check を `gh pr checks ${PR_NUMBER}` で特定し、`gh run view <run-id> --log-failed` で失敗ログを取得。**worktree 内で修正**（repo root で修正すると main を汚染する）→ commit → push → CI 監視を再実行。fix ループは最大 3 周、超過したら人手判断を仰ぐ
 - CI fail が対象 issue のスコープ外（flaky test 等）と判断した場合はユーザーに報告して判断を仰ぐ
 
-7 観点自動レビュー（takt-review スキル）は本 skill では起動しない。ユーザーが明示的に依頼した場合のみ別途起動する（Step 6 で worktree を削除済みのため、fix が必要になったら worktree の再作成が要る）。
+7 観点自動レビュー（takt-review スキル）は本 skill では起動しない。ユーザーが明示的に依頼した場合のみ別途起動する（takt-review は read-only。レビュー結果を報告するだけで fix はしない）。
 
 ### 6. クリーンアップ
 
@@ -444,7 +444,7 @@ takt list --non-interactive --action delete --branch takt/<N>/<slug> --yes
 
 ローカルブランチ `takt/<N>/<slug>` は PR が merge されたあとに `clean-branch` スキルで一括削除する（merge 前に削除すると PR の差分元が失われる）。
 
-クリーンアップ後に takt-review を回す場合、fix 用の worktree は失われているため `git worktree add` で再作成が必要になる（takt-review スキル側の注意書きを参照）。
+クリーンアップ後に takt-review を回しても問題ない。takt-review は read-only（レビュー結果を報告するだけで fix はしない）ため、worktree の再作成は不要。
 
 ### 7. スコープ外の発見は別 issue 化
 
@@ -488,7 +488,7 @@ takt の実行中・完了後にスコープ外の問題に気付いたら、**w
 - **PR 作成で終わらない**: takt CLI の postExecutionFlow が `gh pr create` した後に GitHub Actions が走る。workflow 内のレビューはコード読みだけで CI を回さないため、必ず Step 5-C の CI 監視で green を確認してから完了とする
 - **`Auto-create PR? [Y/n]` は Y を選ぶ**: takt CLI 本体の postExecutionFlow が PR を作る経路を有効化するため。workflow 側に PR 作成 step は存在しないので二重起動の懸念はない
 - **既存 PR 積み上げは人手**: postExecutionFlow は既存 PR を検出すると `gh pr comment` でコメント追記するだけで base ブランチへの merge は行わない。積み上げ運用なら Step 5-B の手動 merge 手順を実行する
-- **7 観点レビューは対象外**: takt-review スキルは本 skill から呼ばない。ユーザーが明示的に依頼した場合のみ別途起動する。その時点で worktree は Step 6 で削除済みのため、fix が必要なら `git worktree add` での再作成が要る
+- **7 観点レビューは対象外**: takt-review スキルは本 skill から呼ばない。ユーザーが明示的に依頼した場合のみ別途起動する。takt-review は read-only（レビュー結果を報告するだけで fix はしない）
 - **実行時間の目安**: 実装（20-40 分）+ CI（数分〜十数分）+ fix ループ（CI fail 時のみ、最大 3 周）
 
 ## Rules

--- a/config/.claude/skills/takt-review/SKILL.md
+++ b/config/.claude/skills/takt-review/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: takt-review
 description: >-
-  takt の review-takt-default で PR を 7 観点自動レビューし、REJECT なら worktree で fix → 再レビューを最大 3 周回す。
-  CI 監視 → レビュー → 判定 → fix ループを一気通貫で実行する。
+  takt の review-takt-default で PR を 7 観点自動レビューし、結果を PR コメントに投稿して報告する（read-only）。
+  CI 監視 → レビュー → 判定報告を一気通貫で実行する。fix は行わない（REJECT はユーザーに報告して判断を仰ぐ）。
   「takt レビュー」「PR レビューして」「レビュー回して」など、takt 経由の PR レビュー意図で発動。
   単体起動専用（takt-issue からの自動呼び出しは廃止。takt-issue は CI green で完了する）。
 ---
@@ -11,11 +11,11 @@ description: >-
 
 ## Overview
 
-takt の `review-takt-default` workflow で PR を自動レビューし、指摘があれば worktree 内で修正 → 再レビューを繰り返すスキル。CI pass 確認からレビュー完了（APPROVE）または人手エスカレーション（3 周 REJECT）までを担当する。
+takt の `review-takt-default` workflow で PR を自動レビューし、結果を PR コメントに投稿して報告する read-only スキル。CI pass 確認からレビュー結果の報告までを担当する。
+
+**fix は行わない**。APPROVE ならそのまま完了、REJECT ならレビュー結果をユーザーに報告して判断を仰ぐ。修正が必要な場合はユーザーが `/code-review` や別スキル、あるいは手動で対応する。
 
 もともと takt-issue の完了後処理から切り出されたスキルだが、現在 takt-issue からの自動呼び出しは行われない（takt-issue は CI green + クリーンアップで完了する）。ユーザーが明示的にレビューを依頼したときに単体で起動する。
-
-**worktree の再作成**: takt-issue は完了時に worktree を削除するため、takt-issue 経由の PR に対して本スキルを回す場合、fix 用の worktree が存在しないことが多い。REJECT で fix が必要になったら `git worktree add <repo-parent>/takt-worktrees/<slug> <branch>` で再作成してから修正する。
 
 ## When to Use
 
@@ -26,8 +26,7 @@ takt の `review-takt-default` workflow で PR を自動レビューし、指摘
 
 | 項目 | 仕様 | 対処 |
 |------|------|------|
-| review workflow | `review-takt-default` は read-only 7 観点レビュー。コード修正は行わない | REJECT 時の fix はスキル側がサブエージェント or 直接実行 |
-| fix に takt は不要 | `review-fix-takt-default` は使わない（takt 起動オーバーヘッドと Codex トークン消費の回避） | worktree 内で直接コード修正 → commit → push |
+| review workflow | `review-takt-default` は read-only 7 観点レビュー。コード修正は行わない | 本スキルも fix はしない。REJECT はユーザーに報告 |
 | token budget guard | takt の長い標準出力が token 消費の主因 | review ログは `tail -80` で末尾のみ。`review-summary.md` だけ全文読む |
 | takt -q の位置 | `-q` はトップレベル option | `takt -q -t ...` の順 |
 
@@ -35,7 +34,6 @@ takt の `review-takt-default` workflow で PR を自動レビューし、指摘
 
 ```bash
 PR_NUM=<PR#>
-WORKTREE=<worktree_path>
 REPO_ROOT=<repo_root>
 
 gh pr view ${PR_NUM} --json title,state,headRefName,url   # PR 情報
@@ -70,9 +68,7 @@ Claude Code では `Bash` の `run_in_background: true` で投げる（timeout `
 完了通知が来たら:
 
 - **exit 0** → 全 check pass。Step 2 へ
-- **exit ≠ 0** → 失敗 check を `gh pr checks ${PR_NUMBER}` で特定し、`gh run view <run-id> --log-failed` で失敗ログを取得。修正は worktree で行い、push 後に Step 1 を再実行
-
-CI fail が対象 PR のスコープ外（flaky test など）と判断した場合は、ユーザーに報告して判断を仰ぐ。
+- **exit ≠ 0** → CI が fail している。レビューはスコープ外なので、失敗 check を `gh pr checks ${PR_NUMBER}` で特定し、`gh run view <run-id> --log-failed` で失敗ログの要点を確認したうえで、ユーザーに報告して判断を仰ぐ（本スキルは修正しない）
 
 ### 2. 自動レビュー
 
@@ -111,116 +107,33 @@ COMMENT
 )"
 ```
 
-### 3. 判定 → fix ループ
+### 3. 判定を報告
 
-`review-summary.md` の `## 総合判定:` を確認し、**APPROVE になるまで Step 4 → Step 2 を繰り返す**（最大 3 周。超えたら人手判断を仰ぐ）。
+`review-summary.md` の `## 総合判定:` を確認し、結果をユーザーに報告して完了する。
 
-```
-REVIEW_ROUND=1
+- **APPROVE** → レビュー通過。PR URL と判定をユーザーに報告して完了
+- **REJECT** → レビュー結果（指摘事項の要点）をユーザーに報告する。**fix は行わない**。修正が必要かどうか、どう修正するかはユーザーの判断に委ねる（ユーザーが `/code-review` や手動修正、別途対応を選ぶ）
 
-loop:
-  判定を読む
-  ├─ APPROVE → ユーザーに報告（完了）
-  └─ REJECT
-       ├─ REVIEW_ROUND >= 3 → ユーザーに状況を報告し人手判断を仰ぐ
-       └─ REVIEW_ROUND < 3
-            → Step 4（fix）実行
-            → Step 2（再レビュー）実行
-            → REVIEW_ROUND++
-            → loop に戻る
-```
-
-### 4. fix（REJECT 時）
-
-`review-summary.md` の指摘事項に基づき、**worktree 内で直接コードを修正** する。
-
-1. `review-summary.md` の全文を読む:
-
-```bash
-RUN_SLUG=$(ls -t .takt/runs/ | head -1)
-cat .takt/runs/${RUN_SLUG}/reports/*review-summary.md
-```
-
-2. worktree 内でコードを修正（**必ず worktree で実行**。repo root で修正すると main を汚染する）:
-
-```bash
-cd <worktree_path>
-```
-
-指摘の重要度順（REJECT 原因 → WARNING → INFO）に該当ファイルを確認する。ただし、**レビュー文面をなぞった表面的な修正で終わらせない**。編集前に各指摘を次の形に分解する:
-
-- レビューが観測した症状
-- その症状を生んだ根本原因（壊れている不変条件、契約、責務分界、データフロー、テスト前提）
-- 同じ原因で壊れうる同型箇所（`rg`、callsite 追跡、周辺テスト確認で探す）
-- 根本原因を取り除く修正方針
-- 回帰を防ぐ検証（既存テスト追加・更新、focused test、手動検証のいずれか）
-
-修正時の判断基準:
-
-- 指摘された行だけを変えるのではなく、同じ設計ミス・仮定漏れ・境界条件漏れが他にもないか探し、PR スコープ内なら一緒に直す
-- hard-code、条件分岐の継ぎ足し、エラー握りつぶしなどでレビュー文面だけを満たす修正は避ける
-- レビューが具体例を 1 件だけ挙げている場合でも、その具体例を bug class の代表として扱い、入力経路・状態遷移・公開 API・テスト期待値まで辿る
-- 既存の設計や helper に沿った修正を優先し、新しい抽象化は重複や責務混在を実際に減らす場合だけ入れる
-- 根本原因が特定できない場合は推測で patch せず、追加調査する。3 周以内に解けない不確実性は PR コメントで明示して人手判断に回す
-
-コミット前に `git diff` を読み、各 REJECT について「原因 → 修正 → 検証」が説明できる状態にする。WARNING/INFO も同じ根本原因に属するものは合わせて処理する。
-
-3. 修正をコミットして push:
-
-```bash
-git add -A
-git commit -m "fix: address review findings round ${REVIEW_ROUND}"
-git push
-```
-
-4. 修正内容を PR コメントに投稿:
-
-```bash
-gh pr comment "${PR_NUM}" --body "$(cat <<COMMENT
-## 🔧 fix round ${REVIEW_ROUND}
-
-review-summary の指摘事項に基づき、根本原因と同型箇所を確認して修正しました。
-
-### 修正内容
-- (修正した内容をリスト)
-
-### 根本原因・横展開
-- (主要な根本原因と、同型箇所を確認した範囲)
-
-### 検証
-- (実行した test / check / 手動確認)
-
-再レビューを実行します。
-COMMENT
-)"
-```
-
-修正後、**Step 2 に戻って再レビュー**を実行する。
+いずれの場合も、投稿済みの PR コメントへのリンクと総合判定を明示して報告する。
 
 ## Gotchas
 
-- **`review-fix-takt-default` は使わない**: takt 起動オーバーヘッドと Codex トークン消費の回避のため、fix は worktree 内で直接実行する
+- **fix は行わない**: 本スキルは read-only。REJECT でもコード修正・再レビューはしない。レビュー結果を報告して終わる
+- **`review-fix-takt-default` は使わない**: fix 自体を本スキルの責務としないため、fix 系 workflow は起動しない
 - **review ログは全文読まない**: `tail -80` で末尾のみ。`review-summary.md` だけ全文読んでよい
-- **worktree で修正**: repo root で修正すると main を汚染する。必ず worktree 内で `cd` してから編集
 - **takt -q の位置**: `-q` はトップレベル option。`takt -q -t ...` の順で指定
 - **レビューの takt ログ**: `.takt/runs/**/logs/*.jsonl` と `trace.md` は全文表示しない。`wc` / `du` / `tail -80` で絞る
-- **APPROVE なら fix 不要**: Step 2 で APPROVE なら Step 4 は実行しない。即完了
-- **表面的な修正は禁止**: 指摘行だけを直して終わらせず、根本原因・同型箇所・回帰検証まで確認する
-- **CI fail がスコープ外の場合**: flaky test 等は修正せず、ユーザーに報告して判断を仰ぐ
-- **クリーンアップは呼び出し元の責務**: このスキルは `takt list --action delete` を実行しない。worktree（fix 用に再作成したものを含む）の削除はユーザーが別途行う（再作成した worktree は `git worktree remove` で片付ける）
+- **CI fail の場合**: レビュー前に CI が fail していたらレビューはスコープ外。ユーザーに報告して判断を仰ぐ
+- **クリーンアップは呼び出し元の責務**: このスキルは `takt list --action delete` を実行しない。worktree の削除はユーザーが別途行う
 - **`npx` は不要**: `takt` を直接実行する
 
 ## Rules
 
 - CI pass を確認してからレビューを開始する。CI をスキップしない
-- `review-takt-default` で APPROVE ならそのまま完了。fix は実行しない
-- REJECT 時は worktree 内で直接コード修正する。`review-fix-takt-default` は使わない
-- REJECT 時は各指摘を「症状 → 根本原因 → 同型箇所 → 修正 → 検証」に分解してから直す
-- 指摘文面だけを満たす hard-code や局所 patch を避け、同じ bug class が再レビューで別指摘にならないよう横展開確認する
-- fix ループは最大 3 周。超えたら人手判断を仰ぐ
+- レビューは read-only。APPROVE でも REJECT でもコード修正・再レビューは行わない
+- REJECT 時はレビュー結果をユーザーに報告して判断を仰ぐ。自動で fix しない
 - review ログは `tail -80` で必要時のみ読む。全文表示禁止
 - `.takt/runs/**/logs/*.jsonl` と `trace.md` は全文表示しない
-- 修正は worktree 内で行う。repo root で修正しない
-- レビュー結果と修正内容は PR コメントに投稿する
+- レビュー結果は PR コメントに投稿し、総合判定をユーザーに報告する
 - `npx` は使わず `takt` を直接実行する
 - このスキルはクリーンアップ（`takt list --action delete`）を実行しない。呼び出し元の責務


### PR DESCRIPTION
review-takt-default の結果を報告するだけの read-only スキルにする。
REJECT でも worktree での自動 fix・再レビューは行わず、
レビュー結果をユーザーに報告して判断を仰ぐ。

- Step 3 の fix ループ（最大 3 周）と Step 4（fix）を削除
- frontmatter / Overview / 前提知識 / Gotchas / Rules を read-only に更新
- worktree 再作成の前提知識を削除（fix しないため不要）
- takt-issue / issue-direct の takt-review 参照を read-only 前提に修正

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HVoV4dNkfdvy3k232p7Ay7