### PR TITLE
feat(nix): takt を Bun グローバルインストールで Nix 管理に統合

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -127,4 +127,12 @@ in
     mkdir -p "$HOME/.takt"
     link_force "${dotfilesDir}/.takt/config.yaml" "$HOME/.takt/config.yaml"
   '';
+
+  # ── takt CLI ──
+  # nixpkgs に takt パッケージは存在しないため、Nix 管理下の bun で
+  # グローバルインストールし、darwin-rebuild switch のたびに最新化する
+  home.activation.installTakt = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    export PATH="${pkgs.bun}/bin:$PATH"
+    "${pkgs.bun}/bin/bun" install -g takt@latest
+  '';
 }


### PR DESCRIPTION
## Summary
- takt (Workflow control for AI coding agents) は nixpkgs に存在しないパッケージのため、既に Nix 管理下にある Bun のグローバルインストール (`bun install -g takt@latest`) を home-manager activation として追加し、`darwin-rebuild switch` のたびに最新化されるようにした
- 既存の Homebrew 版 Node 経由でグローバルインストールされていた旧 takt (`/opt/homebrew/lib/node_modules/takt` および bin symlink 3本) はローカル環境から削除済み(PATH 優先順位により Bun 版と重複・シャドーイングするため)

## Test plan
- [x] `nix-instantiate --parse nix/packages.nix` で構文確認
- [ ] マージ後 `sudo darwin-rebuild switch --flake ~/01-dev/dotfiles#mba` を実行し、`which takt` が `~/.bun/bin/takt` を指し `takt --version` が最新版になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)