### PR TITLE
feat(takt): トークン消費の横断集計ツール takt-usage-report を追加

### DIFF
--- a/config/.local/bin/takt-usage-report
+++ b/config/.local/bin/takt-usage-report
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""takt-usage-report — takt run のトークン消費を横断集計する。
+
+対象ルート配下の .takt/runs/<run>/ を走査し、meta.json(workflow / status /
+startTime)と logs/*-usage-events.phase.jsonl(phase 粒度 usage イベント)を
+突合して、workflow 別 / phase 別 / step 別 / 日次 / top-N run を集計する。
+
+usage:
+  takt-usage-report [ROOT ...] [--days N] [--top N] [--json]
+
+ROOT を省略すると ~/01-dev と ~/02-yt を走査する。
+phase jsonl が無い run(observability 無効期間の run)は「計測なし」として
+件数のみ報告する。
+"""
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+
+DEFAULT_ROOTS = ["~/01-dev", "~/02-yt"]
+
+# 走査から除外するディレクトリ(.takt を含み得ないか、巨大なもの)
+PRUNE_DIRS = {
+    "node_modules", ".git", "dist", "build", "out", "result",
+    ".venv", "venv", ".next", ".cache", ".Trash", "Library",
+}
+
+
+def find_run_dirs(roots):
+    """roots 配下の .takt/runs/<run>/ を列挙する。"""
+    seen = set()
+    for root in roots:
+        root = os.path.realpath(os.path.expanduser(root))
+        for dirpath, dirnames, _ in os.walk(root):
+            if os.path.basename(dirpath) == ".takt":
+                dirnames[:] = []  # .takt 配下は runs だけ見れば良い
+                runs_dir = os.path.join(dirpath, "runs")
+                if not os.path.isdir(runs_dir):
+                    continue
+                for name in sorted(os.listdir(runs_dir)):
+                    run_dir = os.path.join(runs_dir, name)
+                    real = os.path.realpath(run_dir)
+                    if os.path.isdir(run_dir) and real not in seen:
+                        seen.add(real)
+                        yield run_dir
+            else:
+                dirnames[:] = [d for d in dirnames if d not in PRUNE_DIRS]
+
+
+def load_run(run_dir):
+    """1 run 分の meta と phase イベントを読む。meta 不在なら None。"""
+    meta_path = os.path.join(run_dir, "meta.json")
+    try:
+        with open(meta_path) as f:
+            meta = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    events = []
+    logs_dir = os.path.join(run_dir, "logs")
+    if os.path.isdir(logs_dir):
+        for name in os.listdir(logs_dir):
+            if not name.endswith("-usage-events.phase.jsonl"):
+                continue
+            try:
+                with open(os.path.join(logs_dir, name)) as f:
+                    for line in f:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            events.append(json.loads(line))
+                        except json.JSONDecodeError:
+                            continue
+            except OSError:
+                continue
+
+    return {
+        "path": run_dir,
+        "workflow": meta.get("workflow", "(unknown)"),
+        "status": meta.get("status", "(unknown)"),
+        "start_time": meta.get("startTime", ""),
+        "events": events,
+    }
+
+
+def usage_of(event):
+    """usage を provider 差を吸収して正規化する。
+
+    codex: cached_input_tokens は input_tokens の内数。
+    claude: cache_read/cache_creation_input_tokens は input_tokens の外数
+    (total_tokens にも含まれない)ため、input に合算して揃える。
+    """
+    u = event.get("usage") or {}
+    input_ = u.get("input_tokens", 0) or 0
+    output = u.get("output_tokens", 0) or 0
+    cache_read = u.get("cache_read_input_tokens", 0) or 0
+    cache_creation = u.get("cache_creation_input_tokens", 0) or 0
+    if cache_read or cache_creation:
+        input_ += cache_read + cache_creation
+        cached = cache_read
+    else:
+        cached = u.get("cached_input_tokens", 0) or 0
+    return {
+        "total": input_ + output,
+        "input": input_,
+        "output": output,
+        "cached": cached,
+    }
+
+
+def aggregate(runs, top_n):
+    agg = {
+        "runs_measured": 0,
+        "runs_unmeasured": 0,
+        "grand": defaultdict(int),
+        "by_workflow": defaultdict(lambda: defaultdict(int)),
+        "by_phase": defaultdict(lambda: defaultdict(int)),
+        "by_step": defaultdict(lambda: defaultdict(int)),
+        "by_day": defaultdict(lambda: defaultdict(int)),
+        "top_runs": [],
+    }
+    for run in runs:
+        run_total = 0
+        for e in run["events"]:
+            u = usage_of(e)
+            run_total += u["total"]
+            for key in ("total", "input", "output", "cached"):
+                agg["grand"][key] += u[key]
+                agg["by_workflow"][run["workflow"]][key] += u[key]
+                agg["by_phase"][e.get("phase", "(unknown)")][key] += u[key]
+                agg["by_step"][e.get("step", "(unknown)")][key] += u[key]
+
+        if run["events"]:
+            agg["runs_measured"] += 1
+            agg["by_workflow"][run["workflow"]]["runs"] += 1
+            day = run["start_time"][:10] or "(no date)"
+            agg["by_day"][day]["runs"] += 1
+            agg["by_day"][day]["total"] += run_total
+            agg["top_runs"].append({
+                "total": run_total,
+                "workflow": run["workflow"],
+                "status": run["status"],
+                "start_time": run["start_time"],
+                "path": run["path"],
+            })
+        else:
+            agg["runs_unmeasured"] += 1
+
+    agg["top_runs"].sort(key=lambda r: -r["total"])
+    agg["top_runs"] = agg["top_runs"][:top_n]
+    return agg
+
+
+def fmt(n):
+    return f"{n:,}"
+
+
+def pct(part, whole):
+    return f"{100 * part / whole:.1f}%" if whole else "-"
+
+
+def print_markdown(agg, roots, days):
+    grand = agg["grand"]
+    scope = f"直近 {days} 日" if days else "全期間"
+    print(f"# takt usage report ({scope})")
+    print()
+    print(f"- 対象ルート: {', '.join(roots)}")
+    print(f"- 計測あり run: {agg['runs_measured']} / 計測なし run: {agg['runs_unmeasured']}")
+    print(f"- 総トークン: **{fmt(grand['total'])}**"
+          f" (cached {fmt(grand['cached'])} = {pct(grand['cached'], grand['input'])} of input)")
+    print()
+
+    print("## workflow 別")
+    print()
+    print("| workflow | runs | total | avg/run | input | cached% | output |")
+    print("| --- | ---: | ---: | ---: | ---: | ---: | ---: |")
+    for wf, v in sorted(agg["by_workflow"].items(), key=lambda x: -x[1]["total"]):
+        runs = v.get("runs", 0)
+        avg = v["total"] // runs if runs else 0
+        print(f"| {wf} | {runs} | {fmt(v['total'])} | {fmt(avg)} |"
+              f" {fmt(v['input'])} | {pct(v['cached'], v['input'])} | {fmt(v['output'])} |")
+    print()
+
+    print("## phase 別")
+    print()
+    print("| phase | total | share | input | cached% | output |")
+    print("| --- | ---: | ---: | ---: | ---: | ---: |")
+    for ph, v in sorted(agg["by_phase"].items(), key=lambda x: -x[1]["total"]):
+        print(f"| {ph} | {fmt(v['total'])} | {pct(v['total'], grand['total'])} |"
+              f" {fmt(v['input'])} | {pct(v['cached'], v['input'])} | {fmt(v['output'])} |")
+    print()
+
+    print("## step 別 (top 15)")
+    print()
+    print("| step | total | share |")
+    print("| --- | ---: | ---: |")
+    for st, v in sorted(agg["by_step"].items(), key=lambda x: -x[1]["total"])[:15]:
+        print(f"| {st} | {fmt(v['total'])} | {pct(v['total'], grand['total'])} |")
+    print()
+
+    print("## 日次推移")
+    print()
+    print("| date | runs | total |")
+    print("| --- | ---: | ---: |")
+    for day, v in sorted(agg["by_day"].items()):
+        print(f"| {day} | {v['runs']} | {fmt(v['total'])} |")
+    print()
+
+    print(f"## top {len(agg['top_runs'])} runs")
+    print()
+    print("| total | workflow | status | start | run dir |")
+    print("| ---: | --- | --- | --- | --- |")
+    for r in agg["top_runs"]:
+        print(f"| {fmt(r['total'])} | {r['workflow']} | {r['status']} |"
+              f" {r['start_time'][:10]} | {r['path']} |")
+    print()
+
+    print("---")
+    print()
+    print("step×phase の run 単位 drill-down は takt 同梱ツールで:")
+    print()
+    print("    node ~/.bun/install/global/node_modules/takt/dist/commands/analyze-usage.js <run dir>/logs")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="takt run のトークン消費を横断集計する")
+    parser.add_argument("roots", nargs="*", default=None, help=f"走査ルート (default: {' '.join(DEFAULT_ROOTS)})")
+    parser.add_argument("--days", type=int, default=None, help="直近 N 日の run のみ集計")
+    parser.add_argument("--top", type=int, default=10, help="top run の表示件数 (default: 10)")
+    parser.add_argument("--json", action="store_true", help="markdown の代わりに JSON を出力")
+    args = parser.parse_args()
+
+    roots = args.roots or DEFAULT_ROOTS
+    cutoff = None
+    if args.days is not None:
+        cutoff = datetime.now(timezone.utc) - timedelta(days=args.days)
+
+    runs = []
+    for run_dir in find_run_dirs(roots):
+        run = load_run(run_dir)
+        if run is None:
+            continue
+        if cutoff and run["start_time"]:
+            try:
+                started = datetime.fromisoformat(run["start_time"].replace("Z", "+00:00"))
+            except ValueError:
+                started = None
+            if started and started < cutoff:
+                continue
+        runs.append(run)
+
+    agg = aggregate(runs, args.top)
+
+    if args.json:
+        out = {
+            "roots": roots,
+            "days": args.days,
+            "runs_measured": agg["runs_measured"],
+            "runs_unmeasured": agg["runs_unmeasured"],
+            "grand": dict(agg["grand"]),
+            "by_workflow": {k: dict(v) for k, v in agg["by_workflow"].items()},
+            "by_phase": {k: dict(v) for k, v in agg["by_phase"].items()},
+            "by_step": {k: dict(v) for k, v in agg["by_step"].items()},
+            "by_day": {k: dict(v) for k, v in agg["by_day"].items()},
+            "top_runs": agg["top_runs"],
+        }
+        json.dump(out, sys.stdout, ensure_ascii=False, indent=2)
+        print()
+    else:
+        print_markdown(agg, roots, args.days)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/takt-usage-baseline.md
+++ b/docs/takt-usage-baseline.md
@@ -1,0 +1,88 @@
+# takt トークン消費ベースライン (2026-07-05 計測)
+
+`takt-usage-report`(`config/.local/bin/takt-usage-report`、`darwin-rebuild switch` 後は
+`~/.local/bin/takt-usage-report`)による初回計測結果。削減施策の before/after 比較は
+本ツールの再実行で行う。
+
+```sh
+takt-usage-report              # 全期間・markdown
+takt-usage-report --days 7     # 直近 7 日
+takt-usage-report --json       # 機械可読
+```
+
+数値は provider 差を正規化済み(codex は `cached_input_tokens` が input 内数、
+claude は `cache_read/cache_creation_input_tokens` が input 外数のため input に合算)。
+
+## サマリ(全期間: 2026-06-15 〜 2026-07-03)
+
+- 計測あり run: **282**(計測なし = observability 有効化前の run: 24)
+- 総トークン: **約 52.1 億**(cache hit 87.7%)
+- ピーク日: 6/19 に **8.3 億/日**(43 run)。重い日は概ね 5 億前後
+
+## workflow 別
+
+| workflow | runs | total | avg/run |
+| --- | ---: | ---: | ---: |
+| review-takt-default(7 観点レビュー) | 265 | 4,304,697,950 | 16,244,143 |
+| default-mini(実装) | 13 | 658,108,414 | 50,623,724 |
+| review-fix-takt-default(廃止済み) | 3 | 230,251,187 | 76,750,395 |
+| default(実装 + テスト先行) | 1 | 20,096,489 | 20,096,489 |
+
+→ **全体の 83% が review-takt-default**。run 数(265)× 単価(1,600万)の両方が大きい。
+
+## phase 別
+
+| phase | total | share |
+| --- | ---: | ---: |
+| phase1_execute(本来の作業) | 2,721,768,375 | 52.2% |
+| phase2_report(レポート生成の再呼び出し) | 2,436,598,425 | 46.7% |
+| phase3_structured(次 step 判定) | 54,787,240 | 1.1% |
+
+→ **レポート生成だけで全体の 47%**。takt は step ごとに execute → report → structured の
+3 回エージェントを呼び、report は output_contract の report ファイル数ぶん会話全体を
+再送する(`report-phase-runner.ts`)。
+
+## step 別 (top 10)
+
+| step | total | share |
+| --- | ---: | ---: |
+| ai-antipattern-review-2nd | 839,426,720 | 16.1% |
+| coding-review | 661,746,657 | 12.7% |
+| arch-review | 647,599,793 | 12.4% |
+| qa-review | 630,584,164 | 12.1% |
+| pure-review | 577,997,589 | 11.1% |
+| testing-review | 486,439,059 | 9.3% |
+| security-review | 460,431,934 | 8.8% |
+| supervise | 341,286,929 | 6.5% |
+| gather | 185,502,564 | 3.6% |
+| implement | 125,885,325 | 2.4% |
+
+→ **レビュー系 step の合計が全体の約 84%**。実装(implement + fix + plan)は 5% 未満。
+
+## 特記事項
+
+- **aborted run の空費**: default-mini の aborted run が 8,000万〜1.08 億トークンを
+  成果なしで消費(top 10 中 3 件)。abort までの粘りが長い。
+- 最大単一 run は review-fix-takt-default の **2.08 億**(6/19、既にワークフロー廃止済み)。
+- 02-yt / グローバルとも observability は有効で、run ごとの
+  `logs/*-usage-events.phase.jsonl` に計測が残っている(設定変更は不要だった)。
+
+## 削減施策の候補(未実施・要意思決定)
+
+実測に基づく概算効果。上から効果が大きい順:
+
+1. **レビュー観点統合(review-lite 自作)** — gather → 統合レビュアー 1〜2 体 → supervise の
+   カスタム workflow を `config/.takt/workflows/` に作成し、takt-review skill をこれに切替。
+   観点数と同時に phase2_report 回数(= report ファイル数)も減るため、
+   1 run 1,600万 → 400〜500万の見込み(**約 -70%**)。7 観点版は明示依頼時のみ。
+2. **レビュー頻度の運用ルール化** — 265 run 中どれだけが必要だったか。対象 PR を
+   絞るだけで比例削減(現状レビューが全体の 83%)。
+3. **default-mini の draft 内 1st レビュー除去** — `ai-antipattern-review-1st` + `ai-antipattern-fix`
+   (合計 1.6 億、default-mini 内では約 25%)は peer-review 内 2nd と観点が重複。
+   eject して除去すれば実装 run 約 -25%。
+4. **aborted 対策** — abort 判定の早期化(plan 段階の ABORT 条件強化)。1 件で 1 億の空費を防ぐ。
+5. **phase2_report の構造改善** — report が 47% を占めるのは takt 本体の設計。
+   output_contract の report ファイル統合(1 step 1 ファイル)で軽減、
+   根本改善は本家 nrslib/takt への提案(fork 保有: daiki-beppu/takt)。
+6. **persona/model 振り分け** — reviewer 系 persona を軽量モデルへ
+   (`persona_providers.<persona>.model`)。総量は減らないがレート枠の消費を軽減。

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -111,6 +111,9 @@ in
     mkdir -p "$HOME/.local/bin"
     link_force "${dotfilesDir}/.local/bin/open-browser" "$HOME/.local/bin/open-browser"
 
+    # takt トークン消費の横断集計
+    link_force "${dotfilesDir}/.local/bin/takt-usage-report" "$HOME/.local/bin/takt-usage-report"
+
     # zsh-abbr
     mkdir -p "$HOME/.config/zsh-abbr"
     link_force "${dotfilesDir}/.config/zsh-abbr/user-abbreviations" "$HOME/.config/zsh-abbr/user-abbreviations"


### PR DESCRIPTION
## 概要

takt workflow のトークン消費が多い問題の調査基盤。まず実測できる状態を作り、削減施策は計測結果に基づいて別途判断する。

## 変更内容

- **`config/.local/bin/takt-usage-report`**(新規): `~/01-dev` `~/02-yt` 配下の `.takt/runs` を走査し、workflow 別 / phase 別 / step 別 / 日次 / top-N run のトークン消費を markdown または `--json` で集計。codex(`cached_input_tokens` = input 内数)と claude(`cache_read/creation` = input 外数)の usage 形式差を正規化
- **`nix/packages.nix`**: `~/.local/bin/takt-usage-report` への symlink を activation に追加(open-browser と同じパターン)
- **`docs/takt-usage-baseline.md`**(新規): 初回計測ベースラインと削減施策候補

## 初回計測の要点(全期間 2026-06-15〜07-03)

- 総トークン **約 52.1 億**(282 run、cache hit 87.7%)
- **review-takt-default(7 観点レビュー)が 83%**: 265 run × 平均 1,600万
- **phase2_report(レポート生成の再呼び出し)が全体の 47%**
- aborted な default-mini run が 1 億トークン超を空費するケースあり

## 検証

- `takt-usage-report` の集計値が run 単体の takt 同梱 `analyze-usage.js` 出力と一致することを確認
- `--json` が `python3 -m json.tool` を通ることを確認
- `--days 7` フィルタの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)