### PR TITLE
feat: MacBook Pro (daikibeppu) 向けに適応

### DIFF
--- a/config/.claude/settings.json
+++ b/config/.claude/settings.json
@@ -27,8 +27,8 @@
     ],
     "defaultMode": "plan",
     "additionalDirectories": [
-      "/Users/mba/.claude",
-      "/Users/mba/01-dev/dotfiles"
+      "/Users/daikibeppu/.claude",
+      "/Users/daikibeppu/01-dev/dotfiles"
     ]
   },
   "autoMode": {
@@ -89,7 +89,12 @@
     "claude-code-setup@claude-plugins-official": true,
     "commit-commands@claude-plugins-official": true,
     "chrome-devtools-mcp@chrome-devtools-plugins": false,
-    "frontend-design@claude-plugins-official": true
+    "frontend-design@claude-plugins-official": true,
+    "allsmile-tools@allsmile-marketplace": true,
+    "superpowers@claude-plugins-official": true,
+    "playwright@claude-plugins-official": true,
+    "claude-md-management@claude-plugins-official": true,
+    "qodo-skills@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "openai-codex": {

--- a/config/.zshenv
+++ b/config/.zshenv
@@ -1,5 +1,5 @@
 # Vite+ bin (https://viteplus.dev)
-. "$HOME/.vite-plus/env"
+[ -f "$HOME/.vite-plus/env" ] && . "$HOME/.vite-plus/env"
 
 # Bun global packages (bun add -g <pkg>)
 export PATH="$HOME/.bun/bin:$PATH"

--- a/config/.zshrc
+++ b/config/.zshrc
@@ -66,7 +66,7 @@ npm-publish() {
 export BROWSER="$HOME/.local/bin/open-browser"
 
 # Vite+ bin (https://viteplus.dev)
-. "$HOME/.vite-plus/env"
+[ -f "$HOME/.vite-plus/env" ] && . "$HOME/.vite-plus/env"
 export PATH="$HOME/.local/bin:$PATH"
 
 # direnv hook

--- a/flake.nix
+++ b/flake.nix
@@ -23,8 +23,8 @@
       ...
     }:
     let
-      username = "mba";
-      hostname = "mba";
+      username = "daikibeppu";
+      hostname = "MacBook-Pro-3";
       system = "aarch64-darwin";
     in
     {

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -1,13 +1,14 @@
 { pkgs, lib, ... }:
 
 let
-  dotfilesDir = "/Users/mba/01-dev/dotfiles/config";
+  dotfilesDir = "/Users/daikibeppu/01-dev/dotfiles/config";
 in
 {
   home.stateVersion = "24.11";
 
   home.packages = with pkgs; [
     bun
+    nodejs_22
     xz
     cocoapods
     codex
@@ -45,8 +46,18 @@ in
 
     settings = {
       user.name = "daiki-beppu";
-      user.email = "beppu.engineer@gmail.com";
+      user.email = "d.beppu@allsmile.co.jp";
+      push.autoSetupRemote = true;
       init.defaultBranch = "main";
+      credential.helper = "store";
+      "credential \"https://github.com\"".helper = [
+        ""
+        "!/opt/homebrew/bin/gh auth git-credential"
+      ];
+      "credential \"https://gist.github.com\"".helper = [
+        ""
+        "!/opt/homebrew/bin/gh auth git-credential"
+      ];
     };
 
     ignores = [
@@ -122,6 +133,9 @@ in
     link_force "${dotfilesDir}/.claude/statusline-command.sh" "$HOME/.claude/statusline-command.sh"
     link_force "${dotfilesDir}/.claude/hooks" "$HOME/.claude/hooks"
     link_force "${dotfilesDir}/.claude/skills" "$HOME/.claude/skills"
+
+    # WezTerm
+    link_force "${dotfilesDir}/.wezterm.lua" "$HOME/.wezterm.lua"
 
     # takt
     mkdir -p "$HOME/.takt"


### PR DESCRIPTION
## Summary
- flake.nix: username/hostname を `daikibeppu`/`MacBook-Pro-3` に変更
- packages.nix: dotfilesDir パス修正、git email を仕事用に変更、credential helper 追加、`nodejs_22` 追加、`.wezterm.lua` シンボリックリンク追加
- settings.json: additionalDirectories のパス修正、現在のシステムのプラグイン設定をマージ
- .zshrc/.zshenv: vite-plus env のガード追加（未インストール環境でもシェル起動可能に）

## Test plan
- [ ] `nix run nix-darwin -- switch --flake '.#MacBook-Pro-3'` でビルド成功
- [ ] シンボリックリンクが正しく作成される
- [ ] Claude Code が正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)