### PR TITLE
fix(hooks): sync-codex-skills を PostToolUse に登録し reject 系の出力契約を docs 準拠に修正

### DIFF
--- a/config/.claude/hooks/reject-grep.sh
+++ b/config/.claude/hooks/reject-grep.sh
@@ -12,7 +12,7 @@ CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
 # Match standalone grep command (not inside rg, not part of another word)
 if echo "$CMD" | rg -q '(^|[;&|() ])grep(\s|$)'; then
-  echo '{"decision":"block","reason":"grep は禁止。rg (ripgrep) を使ってください"}' >&2
+  echo "grep は禁止。rg (ripgrep) を使ってください" >&2
   exit 2
 fi
 

--- a/config/.claude/hooks/reject-raw-pm.sh
+++ b/config/.claude/hooks/reject-raw-pm.sh
@@ -12,27 +12,27 @@ CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
 # Match standalone npm/yarn/pnpm/npx (not inside another word)
 if echo "$CMD" | rg -q '(^|[;&|() ])npm(\s|$)'; then
-  echo '{"decision":"block","reason":"npm は禁止。ni を使ってください（npm install → ni, npm run → nr）"}' >&2
+  echo "npm は禁止。ni を使ってください（npm install → ni, npm run → nr）" >&2
   exit 2
 fi
 
 if echo "$CMD" | rg -q '(^|[;&|() ])yarn(\s|$)'; then
-  echo '{"decision":"block","reason":"yarn は禁止。ni を使ってください"}' >&2
+  echo "yarn は禁止。ni を使ってください" >&2
   exit 2
 fi
 
 if echo "$CMD" | rg -q '(^|[;&|() ])pnpm(\s|$)'; then
-  echo '{"decision":"block","reason":"pnpm は禁止。ni を使ってください"}' >&2
+  echo "pnpm は禁止。ni を使ってください" >&2
   exit 2
 fi
 
 if echo "$CMD" | rg -q '(^|[;&|() ])npx(\s|$)'; then
-  echo '{"decision":"block","reason":"npx は禁止。nlx を使ってください"}' >&2
+  echo "npx は禁止。nlx を使ってください" >&2
   exit 2
 fi
 
 if echo "$CMD" | rg -q '(^|[;&|() ])bun(x?)(\s|$)'; then
-  echo '{"decision":"block","reason":"bun/bunx は禁止。ni / nlx を使ってください"}' >&2
+  echo "bun/bunx は禁止。ni / nlx を使ってください" >&2
   exit 2
 fi
 

--- a/config/.claude/settings.json
+++ b/config/.claude/settings.json
@@ -61,6 +61,18 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/sync-codex-skills.sh",
+            "timeout": 10
+          }
+        ]
+      }
     ]
   },
   "statusLine": {


### PR DESCRIPTION
## 概要

plans/006-fix-hooks-registration.md の実装。

1. **死んでいた hook の登録**: `config/.claude/hooks/sync-codex-skills.sh` は PostToolUse hook として書かれていたが、`settings.json` に登録がなく一度も実行されていなかった。`hooks.PostToolUse`（matcher `Write|Edit`, timeout 10s）として登録し、スキル編集時の `~/.codex/skills/` への symlink 同期を復活させた。
2. **reject 系 hook の出力契約修正**: reject-grep.sh / reject-raw-pm.sh（npm/yarn/pnpm/npx/bun の 5 ブロック）が「exit 2 + stderr に JSON」を出していたが、公式 docs の契約では exit 2 のとき JSON は無視されプレーンテキスト扱い。stderr をプレーンテキストの理由文に置き換えた（文言は既存 JSON の `reason` 値をそのまま流用）。

## 検証

- `jq -e '.hooks.PostToolUse'` → exit 0、settings.json 全体も valid
- reject-grep / reject-raw-pm の block・pass 単体テスト全系統パス（block: プレーンテキスト stderr + exit 2、pass: 無出力 + exit 0）
- `rg 'decision' config/.claude/hooks/` → マッチなし
- shellcheck `--severity=error` → exit 0
- sync-codex-skills.sh スモークテスト → exit 0、`~/.codex/skills/` への symlink 生成を確認

## マージ後の確認手順

新しい Claude Code セッションでスキルファイルを 1 つ Edit し、`[sync-codex-skills] linked:` 行が出ること（`~/.codex/skills` が無いマシンでは no-op）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)