### PR TITLE
fix(zsh): vite-plus env の source をガードし重複定義を除去

### DIFF
--- a/config/.zshenv
+++ b/config/.zshenv
@@ -1,5 +1,5 @@
 # Vite+ bin (https://viteplus.dev)
-. "$HOME/.vite-plus/env"
+[ -f "$HOME/.vite-plus/env" ] && . "$HOME/.vite-plus/env"
 
 # Bun global packages (bun add -g <pkg>)
 export PATH="$HOME/.bun/bin:$PATH"

--- a/config/.zshrc
+++ b/config/.zshrc
@@ -45,9 +45,9 @@ precmd() {
 
   # タイトルを設定
   if [[ -n "$branch" ]]; then
-    print -Pn "\e]2;[${branch}][${dir}]\a"
+    print -n "\e]2;[${branch}][${dir}]\a"
   else
-    print -Pn "\e]2;[${dir}]\a"
+    print -n "\e]2;[${dir}]\a"
   fi
 }
 
@@ -75,10 +75,6 @@ npm-publish() {
 
 # ターミナルからの URL オープン時の振り分け（認証系 → Chrome、その他 → cmux）
 export BROWSER="$HOME/.local/bin/open-browser"
-
-# Vite+ bin (https://viteplus.dev)
-. "$HOME/.vite-plus/env"
-export PATH="$HOME/.local/bin:$PATH"
 
 # direnv hook
 eval "$(direnv hook zsh)"

--- a/docs/manual-setup.md
+++ b/docs/manual-setup.md
@@ -27,7 +27,11 @@ sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/too
 
 `--keep-zshrc` 必須（インストーラに dotfiles 管理の .zshrc を上書きさせない）。
 
-## 4. アプリの初期設定
+## 4. Vite+ のインストール（任意）
+
+Nix 管理外。公式手順（https://viteplus.dev）でインストールすると `~/.vite-plus/env` が生成され、`.zshenv` がガード付きで自動的に読み込む。未インストールの状態でもシェルはエラーなく起動する。
+
+## 5. アプリの初期設定
 
 | アプリ | 設定内容 |
 |-------|---------|


### PR DESCRIPTION
## 概要

Plan 008（`plans/008-zsh-guard-and-dedup.md`）の実装。PR #65 で入りその後 revert `27f1e3e` で消えた修正の再実装。

## 変更内容

- **config/.zshenv**: `~/.vite-plus/env` の source に `[ -f ... ] &&` ガードを追加。`.zshenv` は非対話含む全 zsh 起動で読まれるため、vite-plus 未インストールのマシンでは全 `zsh -c` 呼び出しの stderr にエラーが乗っていた
- **config/.zshrc**: 重複していた vite-plus source + `~/.local/bin` PATH 追記の 3 行ブロックを削除（`.zshenv` 側だけで読み込む）。precmd の `print -Pn` 2 箇所を `print -n` に修正し、ディレクトリ/ブランチ名中の `%` がタブタイトルでプロンプト展開される誤動作を解消
- **docs/manual-setup.md**: vite-plus の手動インストール手順を §4 として追加

## 検証

- `zsh -n config/.zshenv && zsh -n config/.zshrc` → exit 0
- クリーン HOME（vite-plus なし）で `source config/.zshenv` → stderr 空
- `%` を含むパスでのタイトル出力テスト → `100%done` がそのまま保持される
- `rg -c 'vite-plus' config/.zshrc` → 0、`rg -c 'print -Pn' config/.zshrc` → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)