### PR TITLE
fix(hooks): reject hooks が引用文字列内の禁止語に誤発動しないよう修正

### DIFF
--- a/config/.claude/hooks/reject-grep.sh
+++ b/config/.claude/hooks/reject-grep.sh
@@ -10,8 +10,12 @@ fi
 
 CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
+# 引用文字列の中身は実行されないコマンドなのでマッチ対象から除外する
+# （エスケープされた引用符などの完全な構文解析はしない — soft guardrail で十分）
+STRIPPED=$(printf '%s' "$CMD" | sed -E "s/'[^']*'//g; s/\"[^\"]*\"//g")
+
 # Match standalone grep command (not inside rg, not part of another word)
-if echo "$CMD" | rg -q '(^|[;&|() ])grep(\s|$)'; then
+if echo "$STRIPPED" | rg -q '(^|[;&|() ])grep(\s|$)'; then
   echo "grep は禁止。rg (ripgrep) を使ってください" >&2
   exit 2
 fi

--- a/config/.claude/hooks/reject-raw-pm.sh
+++ b/config/.claude/hooks/reject-raw-pm.sh
@@ -10,28 +10,32 @@ fi
 
 CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
+# 引用文字列の中身は実行されないコマンドなのでマッチ対象から除外する
+# （エスケープされた引用符などの完全な構文解析はしない — soft guardrail で十分）
+STRIPPED=$(printf '%s' "$CMD" | sed -E "s/'[^']*'//g; s/\"[^\"]*\"//g")
+
 # Match standalone npm/yarn/pnpm/npx (not inside another word)
-if echo "$CMD" | rg -q '(^|[;&|() ])npm(\s|$)'; then
+if echo "$STRIPPED" | rg -q '(^|[;&|() ])npm(\s|$)'; then
   echo "npm は禁止。ni を使ってください（npm install → ni, npm run → nr）" >&2
   exit 2
 fi
 
-if echo "$CMD" | rg -q '(^|[;&|() ])yarn(\s|$)'; then
+if echo "$STRIPPED" | rg -q '(^|[;&|() ])yarn(\s|$)'; then
   echo "yarn は禁止。ni を使ってください" >&2
   exit 2
 fi
 
-if echo "$CMD" | rg -q '(^|[;&|() ])pnpm(\s|$)'; then
+if echo "$STRIPPED" | rg -q '(^|[;&|() ])pnpm(\s|$)'; then
   echo "pnpm は禁止。ni を使ってください" >&2
   exit 2
 fi
 
-if echo "$CMD" | rg -q '(^|[;&|() ])npx(\s|$)'; then
+if echo "$STRIPPED" | rg -q '(^|[;&|() ])npx(\s|$)'; then
   echo "npx は禁止。nlx を使ってください" >&2
   exit 2
 fi
 
-if echo "$CMD" | rg -q '(^|[;&|() ])bun(x?)(\s|$)'; then
+if echo "$STRIPPED" | rg -q '(^|[;&|() ])bun(x?)(\s|$)'; then
   echo "bun/bunx は禁止。ni / nlx を使ってください" >&2
   exit 2
 fi


### PR DESCRIPTION
## 概要

plans/009-reject-hooks-quoted-strings.md の実装。

PreToolUse hook の `reject-grep.sh` / `reject-raw-pm.sh` はコマンド文字列全体に素朴に正規表現マッチしていたため、引用文字列内の禁止語にも誤発動していた（例: `git commit -m "replace grep with rg"` がブロックされる）。禁止語はコミットメッセージや PR 本文に頻出するため日常的な摩擦になっていた。

## 変更内容

- `CMD` からシングル/ダブルクォート区間を `sed` で除去した `STRIPPED` を作成し、全 6 個の禁止語マッチ（grep / npm / yarn / pnpm / npx / bun(x)）の対象を `STRIPPED` に切り替え
- 既存の正規表現・エラーメッセージ・exit code は不変。fail-open 特性（jq/rg 不在時はブロックしない）も維持

## 検証

- 検証マトリクス 11 ケース + 追加の敵対ケース 2 件（引用の後ろに実コマンドが続く場合にブロックが維持されること）が全て期待どおり
- shellcheck --severity=error → exit 0
- 変更は in-scope の 2 ファイルのみ

## 既知の限界（意図的に許容）

エスケープ引用符のネスト、heredoc 内の禁止語、無空白連結（`npm&&true` 等）は扱えない。soft guardrail としての実用性を優先。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
