### PR TITLE
fix(hooks): sync-codex-skills を ~/.claude/skills 経由の編集でも発火させる

### DIFF
--- a/config/.claude/hooks/sync-codex-skills.sh
+++ b/config/.claude/hooks/sync-codex-skills.sh
@@ -12,7 +12,7 @@ fi
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 
 case "$FILE_PATH" in
-  */config/.claude/skills/*) ;;
+  */.claude/skills/*) ;;
   *) exit 0 ;;
 esac
 


### PR DESCRIPTION
## 概要

`sync-codex-skills.sh`（PostToolUse hook）の発火条件が `*/config/.claude/skills/*` という repo パス限定だったため、デプロイ先 symlink（`~/.claude/skills/...`）経由の Write/Edit では同じ実ファイルを編集しているのに Codex 同期がスキップされ、`~/.codex/skills` が黙ってドリフトしていた。

case パターンを `*/.claude/skills/*` に広げ、両経路で発火するようにする（repo パスは新パターンの部分集合なので 1 本に集約）。

## 変更内容

- `config/.claude/hooks/sync-codex-skills.sh`: case パターン 1 行のみ

## 検証

- 偽 `HOME` での 3 経路テスト（レビュアーも独立に再実行して確認）:
  - symlink 経由パス → symlink 作成 ✅（従来はスキップされていたケース）
  - repo パス → symlink 作成 ✅（従来どおり）
  - 無関係パス → exit 0・リンク作成なし ✅（`~/.codex/skills` 自身にも誤発火しない）
- `shellcheck --severity=error` → exit 0

Plan: `plans/010-sync-codex-skills-matcher.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)