### PR TITLE
feat(nix): turso/sqld を Homebrew tap から nixpkgs へ移行

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -120,13 +120,10 @@
 
                   taps = [
                     "manaflow-ai/cmux"
-                    "libsql/sqld"
-                    "tursodatabase/tap"
                   ];
 
                   brews = [
                     "ni"
-                    "tursodatabase/tap/turso"
                   ];
 
                   casks = [

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -27,6 +27,8 @@ in
     tree
     unzip
     uv
+    sqld
+    turso-cli
     zsh-abbr
 
     # Python + youtube-channels 自動化に必要なパッケージ


### PR DESCRIPTION
## 変更内容

- `flake.nix`: Homebrew の `libsql/sqld` / `tursodatabase/tap` の tap と `tursodatabase/tap/turso` brew を削除
- `nix/packages.nix`: nixpkgs の `sqld` / `turso-cli` を追加

## 理由

turso / sqld を Homebrew tap 経由ではなく nixpkgs で管理することで、パッケージ管理を Nix に一本化する。

## レビュー時の注意

- 適用には `darwin-rebuild switch` が必要
- 既存の brew 版 turso が残っている場合、PATH の優先順位によってはそちらが使われる可能性あり(`brew uninstall` 推奨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)