### PR TITLE
feat(flake): hosts にホスト差分の注入点を追加

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,11 @@
     }:
     let
       system = "aarch64-darwin";
+      # ホスト差分の注入点（3 つ）:
+      #   - gitEmail: home-manager 側の git user.email を上書き（未指定ならデフォルトの private email）
+      #   - extraPackages: pkgs -> [ ... ] 形式で home.packages に追加パッケージを足す
+      #   - extraModules: nix-darwin モジュールのリストを追加（casks / system.defaults のホスト分割等）
+      # PR #65 型の変更（ホスト固有のハードコード）は今後ここに入れる。
       hosts = {
         "MacBook-Pro-3" = {
           username = "daikibeppu";
@@ -34,7 +39,14 @@
       };
       mkDarwin =
         hostname:
-        { username }:
+        hostAttrs:
+        let
+          username = hostAttrs.username;
+          hostConfig = {
+            gitEmail = hostAttrs.gitEmail or "beppu.engineer@gmail.com";
+            extraPackages = hostAttrs.extraPackages or (pkgs: [ ]);
+          };
+        in
         nix-darwin.lib.darwinSystem {
           inherit system;
 
@@ -165,9 +177,10 @@
               home-manager.useGlobalPkgs = true;
               home-manager.useUserPackages = true;
               home-manager.backupFileExtension = "backup";
+              home-manager.extraSpecialArgs = { inherit hostConfig; };
               home-manager.users.${username} = import ./nix/packages.nix;
             }
-          ];
+          ] ++ (hostAttrs.extraModules or [ ]);
         };
     in
     {

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -2,6 +2,7 @@
   pkgs,
   lib,
   config,
+  hostConfig,
   ...
 }:
 
@@ -47,7 +48,7 @@ in
         pyyaml
       ]
     ))
-  ];
+  ] ++ (hostConfig.extraPackages pkgs);
 
   # ── git 設定 ──
   programs.git = {
@@ -55,7 +56,7 @@ in
 
     settings = {
       user.name = "daiki-beppu";
-      user.email = "beppu.engineer@gmail.com";
+      user.email = hostConfig.gitEmail;
       init.defaultBranch = "main";
     };
 


### PR DESCRIPTION
## Summary
- `mkDarwin` の引数パターンを `{ username }` から `hostAttrs` に開放し、ホスト差分の注入点を 3 つ追加
  - `gitEmail`: per-host の git user.email（デフォルト: `beppu.engineer@gmail.com`）
  - `extraPackages`: `pkgs -> [ ... ]` 形式で home.packages に追加パッケージ
  - `extraModules`: nix-darwin モジュールのリスト追加（casks / system.defaults のホスト分割等）
- `extraSpecialArgs` で `hostConfig` を Home Manager に伝搬し、`nix/packages.nix` で消費
- PR #65 型の事故（ホスト固有のハードコード → 相手ホスト破壊 → 全 revert）を防ぐ受け皿

## Test plan
- [x] 両ホストの `nix eval ... system.drvPath` が exit 0（挙動不変）
- [x] email eval がデフォルト値 `beppu.engineer@gmail.com` を返す
- [x] 一時差分テスト: mba に `gitEmail = "test@example.com"` を入れて mba 側のみ変化、MacBook-Pro-3 側は不変を確認 → 差分除去
- [x] `rg -c 'extraSpecialArgs' flake.nix` → 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)