### PR TITLE
chore(ci): actions/checkout@v5・nix-installer-action@v22 に更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: DeterminateSystems/nix-installer-action@v22
       - name: Evaluate darwin configuration
         run: bash scripts/check.sh nix-eval
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     name: Nix flake evaluation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@v16
       - name: Evaluate darwin configuration
         run: bash scripts/check.sh nix-eval
@@ -19,7 +19,7 @@ jobs:
     name: ShellCheck (severity=error)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install shellcheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
       - name: Run shellcheck, link-manifest drift, and skill/workflow contract checks


### PR DESCRIPTION
## 概要

CI の annotation に出ていた Node.js 20 deprecation 警告を解消するため、`ci.yml` の action を更新する。

- `actions/checkout`: v4 → v5（2 箇所）
- `DeterminateSystems/nix-installer-action`: v16 → v22（checkout 更新後の CI run で同じ警告が残っていたため追加）

## 背景

GitHub Actions ランナーで Node.js 20 が非推奨となり、v4 / v16 は Node.js 24 で強制実行されている（[GitHub changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)）。

## レビュー観点

- 挙動変更はなし（いずれも Node ランタイム更新が主）。この PR 自体の CI が green かつ deprecation annotation が消えることが動作確認を兼ねる

🤖 Generated with [Claude Code](https://claude.com/claude-code)