### PR TITLE
fix(takt): supervisor モデルを gpt-5.6-terra に統一し solid の implement を既定モデル化

### DIFF
--- a/config/.takt/workflows/diagnose-fix.yaml
+++ b/config/.takt/workflows/diagnose-fix.yaml
@@ -126,7 +126,7 @@ steps:
     edit: false
     persona: supervisor
     provider: codex
-    model: gpt-5
+    model: gpt-5.6-terra
     provider_options:
       claude:
         allowed_tools:

--- a/config/.takt/workflows/fix.yaml
+++ b/config/.takt/workflows/fix.yaml
@@ -51,7 +51,7 @@ steps:
     edit: false
     persona: supervisor
     provider: codex
-    model: gpt-5
+    model: gpt-5.6-terra
     policy: review
     provider_options:
       claude:

--- a/config/.takt/workflows/solid.yaml
+++ b/config/.takt/workflows/solid.yaml
@@ -83,9 +83,8 @@ steps:
       - coding
     persona: coder
     provider: codex
-    # lite の失敗を経た task なので、最初から最高段の推論性能で実装する
-    # （lite は promotion で 3 巡目にようやく sol。ここでは昇格を待たない）。
-    model: gpt-5.6-sol
+    # 長時間の実装セッションで tool error 後に応答を返さないことがあるため、
+    # 既定の Codex モデルで実行する。検証・レビュー工程は workflow 側で維持する。
     edit: true
     required_permission_mode: edit
     pass_previous_response: true
@@ -100,6 +99,8 @@ steps:
       - 項目 1 の受入条件充足表（要件の引用 / 対応する実装行 / 対応するテスト）を応答の末尾に必ず含める
       - テストの実行コマンドと green の出力を応答に貼る
       - 未充足・未照合の項目が残る場合は完了を宣言せず、解消してから完了すること
+      - 依存不足・権限・ネットワーク等で検証できない場合、`rm -rf`、symlink 作成、
+        `pnpm add` 等で環境を自己修復しない。原因と未実行の検証を報告して終了すること
     rules:
       - condition: "実装・テスト・セルフ監査 8 項目の照合がすべて完了した"
         next: review


### PR DESCRIPTION
## What

- **fix.yaml / diagnose-fix.yaml**: supervisor step のみ旧 `gpt-5` を固定していたため、他 workflow のレビュー工程と同じ `gpt-5.6-terra` に統一
- **solid.yaml**:
  - implement step の `model: gpt-5.6-sol` 固定を外し、既定の Codex モデルで実行するように変更
  - 検証不能時（依存不足・権限・ネットワーク等）に `rm -rf` / symlink 作成 / `pnpm add` 等で環境を自己修復せず、原因と未実行の検証を報告して終了するルールを追加

## Why

- supervisor step の旧モデル固定が workflow 失敗の原因になっていた
- solid の長時間実装セッションで gpt-5.6-sol 固定だと tool error 後に応答を返さないことがあった

## Verification

- `takt workflow doctor` で 3 ファイルすべて Workflow OK を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)