### PR TITLE
chore(nix): flake inputs 更新 + nixpkgs 716c7a2 の darwin ビルド不具合を回避

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783689750,
-        "narHash": "sha256-iMO/Ypany7DPXD6D7sQgH7METtEUihnOvdb+A9ehn8k=",
+        "lastModified": 1783823409,
+        "narHash": "sha256-OI4IkRjRXa1e7hYmCGJDPDq5H/kPwhsyoS80cNUF9fI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "79e6082586b3680ff32c8e75127545058f074fa4",
+        "rev": "7566825d4652a1b885bd4ce65bd9e8def432fec9",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783475452,
-        "narHash": "sha256-3S92fSuv32mjJz2Qb2F4405c21J55F4NIphz5K6hxco=",
+        "lastModified": 1783791668,
+        "narHash": "sha256-zbcZ1dmBTPfJ7Mlqh/yLEPGpgJnwuv4Xr1xucy2WqMA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "05988b07fb05cbcb50be6bce197b4b5f75b5e61b",
+        "rev": "716c7a2664ca8325617b8a7fbb609273f2c4cae7",
         "type": "github"
       },
       "original": {

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -18,7 +18,9 @@ in
     cocoapods
     codex
     direnv
-    ffmpeg-full
+    # nixpkgs 716c7a2 で依存の whisper-cpp が darwin でビルド不能（CoreML リンク時に
+    # ld がクラッシュ）なため、whisper フィルタを無効化（上流修正後に外す）
+    (ffmpeg-full.override { withWhisper = false; })
     gh
     google-cloud-sdk
     gzip
@@ -40,7 +42,11 @@ in
         google-auth-httplib2
         pandas
         matplotlib
-        seaborn
+        # nixpkgs 716c7a2 で test_ticklabels_overlap が darwin で失敗するため
+        # テストをスキップ（上流修正後に外す）
+        (seaborn.overridePythonAttrs (old: {
+          doCheck = false;
+        }))
         schedule
         python-dotenv
         pillow


### PR DESCRIPTION
## 変更内容

- flake inputs を更新
  - nixpkgs: `05988b0` (2026-07-08) → `716c7a2` (2026-07-11)
  - home-manager: `79e6082` → `7566825`
- nixpkgs 716c7a2 の darwin ビルド不具合を回避する一時 override を追加
  - **seaborn**: `test_ticklabels_overlap` が darwin で deterministic に失敗するため `doCheck = false`（Hydra でも失敗しておりキャッシュ未提供）
  - **ffmpeg-full**: 依存の whisper-cpp が CoreML dylib リンク時に cctools ld のクラッシュ（`Trace/BPT trap: 5`）でビルド不能なため `withWhisper = false`。whisper フィルタは ffmpeg 8 の新機能で従来環境には存在しなかったため実用上の後退なし

## 背景

`nix flake update` 後の `darwin-rebuild switch` が上記 2 パッケージで失敗したため。terraform (unfree・キャッシュ非提供) のソースビルドは成功済み。

## レビュー時の注意

- 2 つの override はいずれも一時措置。上流修正後に外す（コメントに明記済み）
- `darwin-rebuild switch` が完走し、terraform 1.15.8 / ffmpeg 8.1.2 / codex 0.144.1 / gh 2.96.0 の動作を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)