### PR TITLE
chore(takt): 全 workflow の max_steps を約1.5倍に引き上げ

### DIFF
--- a/config/.takt/workflows/diagnose-fix.yaml
+++ b/config/.takt/workflows/diagnose-fix.yaml
@@ -24,7 +24,7 @@ workflow_config:
       network_access: true
     opencode:
       network_access: true
-max_steps: 10
+max_steps: 15
 initial_step: diagnose
 steps:
   - name: diagnose

--- a/config/.takt/workflows/docs.yaml
+++ b/config/.takt/workflows/docs.yaml
@@ -11,7 +11,7 @@
 #   structured_output + `when:` で Phase 3 を完全にスキップ、全 step provider: codex を明示）
 name: docs
 description: ドキュメント・skill 改善用の最軽量 workflow（実装 → 整合実証レビューの 2 step）。コード変更を伴うタスクは lite / improve を使う
-max_steps: 6
+max_steps: 9
 steps:
   - name: implement
     persona: coder

--- a/config/.takt/workflows/e2e-verify.yaml
+++ b/config/.takt/workflows/e2e-verify.yaml
@@ -6,7 +6,7 @@ workflow_config:
       network_access: true
     opencode:
       network_access: true
-max_steps: 10
+max_steps: 15
 initial_step: plan
 
 steps:

--- a/config/.takt/workflows/feature.yaml
+++ b/config/.takt/workflows/feature.yaml
@@ -26,7 +26,7 @@ workflow_config:
       network_access: true
     opencode:
       network_access: true
-max_steps: 20
+max_steps: 30
 initial_step: plan
 loop_monitors:
   - cycle:

--- a/config/.takt/workflows/fix.yaml
+++ b/config/.takt/workflows/fix.yaml
@@ -6,7 +6,7 @@ workflow_config:
       network_access: true
     opencode:
       network_access: true
-max_steps: 15
+max_steps: 24
 initial_step: fix
 
 steps:

--- a/config/.takt/workflows/improve.yaml
+++ b/config/.takt/workflows/improve.yaml
@@ -16,7 +16,7 @@
 #   structured_output + `when:` で Phase 3 を完全にスキップ、全 step provider: codex を明示）
 name: improve
 description: 機能改善（既存機能の挙動変更・拡張）用 workflow。挙動変更影響表で意図した変更と回帰を区別する。interface 変更を伴う場合は feature を使う
-max_steps: 8
+max_steps: 12
 steps:
   - name: plan
     persona: planner

--- a/config/.takt/workflows/lite.yaml
+++ b/config/.takt/workflows/lite.yaml
@@ -12,7 +12,7 @@
 # - 全 step provider: codex を明示（02-yt と挙動・トークン特性を揃える意図的な選択。
 #   グローバル config のハイブリッド方針（レビュー系 = Claude）はこの workflow には適用しない）
 name: lite
-max_steps: 8
+max_steps: 12
 steps:
   - name: plan
     persona: planner

--- a/config/.takt/workflows/review-lite.yaml
+++ b/config/.takt/workflows/review-lite.yaml
@@ -43,7 +43,7 @@
 #   方針（レビュー系 = Claude）はこの workflow には適用しない）
 # - 全 step edit: false（read-only レビュー。コード修正は takt-review skill 側が担当）
 name: review-lite
-max_steps: 4
+max_steps: 6
 steps:
   - name: review
     persona: coding-reviewer

--- a/config/.takt/workflows/solid.yaml
+++ b/config/.takt/workflows/solid.yaml
@@ -19,7 +19,7 @@
 # - 全 step provider: codex を明示（lite と挙動・トークン特性を揃える）
 name: solid
 description: lite の一段上の堅牢版。lite で完了できなかった task の再走が主用途（失敗原因分析 → 再計画 → ゼロから再実装 → レビュー）。スコープ過大なら分割提案を出して停止
-max_steps: 12
+max_steps: 18
 initial_step: plan
 loop_monitors:
   - cycle:


### PR DESCRIPTION
## 概要

takt オリジナル workflow 9 個の `max_steps` を、fix ループや supervisor 差し戻しで上限超過による中断が起きにくいよう約 1.5 倍に引き上げる。

## 変更内容

| workflow | before | after |
|---|---|---|
| feature | 20 | 30 |
| fix | 15 | 24 |
| solid | 12 | 18 |
| diagnose-fix | 10 | 15 |
| e2e-verify | 10 | 15 |
| lite | 8 | 12 |
| improve | 8 | 12 |
| docs | 6 | 9 |
| review-lite | 4 | 6 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)