### PR TITLE
feat(nix): herdr を追加

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -24,6 +24,7 @@ in
     gh
     google-cloud-sdk
     gzip
+    herdr
     ripgrep
     terraform
     tmux


### PR DESCRIPTION
## 概要
エージェントマルチプレクサ [herdr](https://herdr.dev/) を `nix/packages.nix` の CLI パッケージに追加。

- pin 済み nixpkgs に `herdr` 0.7.3 が存在することを確認済み
- `darwin-rebuild build` でビルド検証済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)