### PR TITLE
fix(takt): review-verdict schema の required に followups を追加

### DIFF
--- a/config/.takt/schemas/review-verdict.json
+++ b/config/.takt/schemas/review-verdict.json
@@ -3,7 +3,11 @@
   "properties": {
     "verdict": {
       "type": "string",
-      "enum": ["approved", "needs_fix", "blocked"]
+      "enum": [
+        "approved",
+        "needs_fix",
+        "blocked"
+      ]
     },
     "feedback": {
       "type": "string",
@@ -11,28 +15,53 @@
     },
     "followups": {
       "type": "array",
-      "description": "レビュー中に見つけたスコープ外の問題（verdict の判定材料にしない）。起票判断は Claude Code 層が行う。省略可・なければ空配列",
+      "description": "レビュー中に見つけたスコープ外の問題（verdict の判定材料にしない）。起票判断は Claude Code 層が行う。なければ空配列（strict structured output のため必須キー）",
       "items": {
         "type": "object",
         "properties": {
-          "title": { "type": "string" },
-          "description": { "type": "string" },
-          "evidence": { "type": "string", "description": "根拠（ファイル:行、観測した挙動）" }
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "evidence": {
+            "type": "string",
+            "description": "根拠（ファイル:行、観測した挙動）"
+          }
         },
-        "required": ["title", "description", "evidence"],
+        "required": [
+          "title",
+          "description",
+          "evidence"
+        ],
         "additionalProperties": false
       }
     }
   },
-  "required": ["verdict", "feedback"],
+  "required": [
+    "verdict",
+    "feedback",
+    "followups"
+  ],
   "allOf": [
     {
       "if": {
-        "properties": { "verdict": { "const": "blocked" } },
-        "required": ["verdict"]
+        "properties": {
+          "verdict": {
+            "const": "blocked"
+          }
+        },
+        "required": [
+          "verdict"
+        ]
       },
       "then": {
-        "properties": { "feedback": { "minLength": 1 } }
+        "properties": {
+          "feedback": {
+            "minLength": 1
+          }
+        }
       }
     }
   ],

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -400,13 +400,14 @@ async function expectInvalid(payload, detail) {
 function runPreflightFixture(root) {
   const script = join(root, '.takt', 'quality-gates', 'preflight.sh');
   const probe = spawnSync('test', ['-f', script], { cwd: root });
-  if (probe.status !== 0) return { verdict: 'approved', feedback: '' };
+  if (probe.status !== 0) return { verdict: 'approved', feedback: '', followups: [] };
   const result = spawnSync('bash', ['.takt/quality-gates/preflight.sh'], { cwd: root, encoding: 'utf8' });
-  if (result.status === 0) return { verdict: 'approved', feedback: '' };
+  if (result.status === 0) return { verdict: 'approved', feedback: '', followups: [] };
   const output = `${result.stdout}${result.stderr}`.trim();
   return {
     verdict: 'blocked',
     feedback: `bash .takt/quality-gates/preflight.sh exited ${result.status}: ${output}`,
+    followups: [],
   };
 }
 
@@ -439,17 +440,18 @@ if (!failed.feedback.includes('exited 23') || !failed.feedback.includes('daemon-
 if (await runEngineScenario('preflight', failed, failureDir) !== 'ABORT') {
   throw new Error(`${workflowName}: failed preflight does not route to ABORT`);
 }
-await expectInvalid({ verdict: 'blocked', feedback: '' }, 'blocked with empty feedback');
-await expectInvalid({ verdict: 'unknown', feedback: 'detail' }, 'unknown verdict');
+await expectInvalid({ verdict: 'blocked', feedback: '', followups: [] }, 'blocked with empty feedback');
+await expectInvalid({ verdict: 'unknown', feedback: 'detail', followups: [] }, 'unknown verdict');
+await expectInvalid({ verdict: 'approved', feedback: '' }, 'missing followups key');
 
-if (await runEngineScenario(review.name, { verdict: 'approved', feedback: '' }) !== 'COMPLETE') {
+if (await runEngineScenario(review.name, { verdict: 'approved', feedback: '', followups: [] }) !== 'COMPLETE') {
   throw new Error(`${workflowName}: approved ${review.name} does not route to COMPLETE`);
 }
 const needsFixTarget = workflowName === 'diagnose-fix' ? 'fix' : 'implement';
-if (await runEngineScenario(review.name, { verdict: 'needs_fix', feedback: 'code defect' }) !== needsFixTarget) {
+if (await runEngineScenario(review.name, { verdict: 'needs_fix', feedback: 'code defect', followups: [] }) !== needsFixTarget) {
   throw new Error(`${workflowName}: needs_fix ${review.name} does not route to ${needsFixTarget}`);
 }
-if (await runEngineScenario(review.name, { verdict: 'blocked', feedback: 'daemon unavailable' }) !== 'ABORT') {
+if (await runEngineScenario(review.name, { verdict: 'blocked', feedback: 'daemon unavailable', followups: [] }) !== 'ABORT') {
   throw new Error(`${workflowName}: blocked ${review.name} does not route to ABORT`);
 }
 rmSync(fixtureRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- `review-verdict.json` の `required` を `["verdict", "feedback", "followups"]` に修正
- contracts のフィクスチャ payload に `followups: []` を追加し、followups 欠落 payload の拒否テストを新設

## 背景

OpenAI (codex provider) の strict structured output は `properties` の全キーが `required` に含まれることを要求する。#97 で `blocked` enum は追加されたが `required` の修正が漏れており、repo ローカル override を持たないリポジトリでは review step が 400 (`invalid_json_schema`) になる（#96 の初回 takt run で観測した事象の残件）。

## 検証

- `bash scripts/check.sh contracts` → all checks passed
- `bash scripts/check.sh shellcheck links` → all checks passed

関連: #96 / #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)