### PR TITLE
fix(takt): review-verdict schema から allOf を除去（OpenAI strict モード非対応）

### DIFF
--- a/config/.takt/schemas/review-verdict.json
+++ b/config/.takt/schemas/review-verdict.json
@@ -11,7 +11,7 @@
     },
     "feedback": {
       "type": "string",
-      "description": "needs_fix の場合の修正指示（具体的なファイル・箇所・理由）、blocked の場合の検証不能となった環境障害の内容。approved なら空文字"
+      "description": "needs_fix の場合の修正指示（具体的なファイル・箇所・理由）、blocked の場合は検証不能となった環境障害の内容（空文字にしない）。approved なら空文字"
     },
     "followups": {
       "type": "array",
@@ -43,27 +43,6 @@
     "verdict",
     "feedback",
     "followups"
-  ],
-  "allOf": [
-    {
-      "if": {
-        "properties": {
-          "verdict": {
-            "const": "blocked"
-          }
-        },
-        "required": [
-          "verdict"
-        ]
-      },
-      "then": {
-        "properties": {
-          "feedback": {
-            "minLength": 1
-          }
-        }
-      }
-    }
   ],
   "additionalProperties": false
 }

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -254,6 +254,19 @@ check_contracts() {
     done < <(sed -nE 's/^[[:space:]]*schema_ref:[[:space:]]*([a-z0-9-]+)[[:space:]]*$/\1/p' "$f")
   done
 
+  echo "-- checking schemas avoid OpenAI-strict-incompatible keywords --"
+  # codex provider は response_format に schema をそのまま渡す。strict mode は
+  # 条件付き検証（allOf/if/then 等）を許可せず 400 になるため、静的に弾く。
+  local sf bad
+  for sf in "$schemas_dir"/*.json; do
+    [ -f "$sf" ] || continue
+    if bad="$(grep -nE '"(allOf|anyOf|oneOf|if|then|else|not|\$ref)"[[:space:]]*:' "$sf")"; then
+      echo "INVALID: $sf uses strict-mode-incompatible keyword(s):" >&2
+      echo "$bad" >&2
+      status=1
+    fi
+  done
+
   echo "-- checking review-verdict workflow preflight and blocked routes --"
   local takt_bin
   if ! takt_bin="$(command -v takt)"; then
@@ -440,7 +453,8 @@ if (!failed.feedback.includes('exited 23') || !failed.feedback.includes('daemon-
 if (await runEngineScenario('preflight', failed, failureDir) !== 'ABORT') {
   throw new Error(`${workflowName}: failed preflight does not route to ABORT`);
 }
-await expectInvalid({ verdict: 'blocked', feedback: '', followups: [] }, 'blocked with empty feedback');
+// blocked の非空 feedback は schema では強制しない（OpenAI strict モードが
+// allOf/if/then を許可しないため）。review instruction 側の規律に委ねる。
 await expectInvalid({ verdict: 'unknown', feedback: 'detail', followups: [] }, 'unknown verdict');
 await expectInvalid({ verdict: 'approved', feedback: '' }, 'missing followups key');
 


### PR DESCRIPTION
## Summary

- `review-verdict.json` から `allOf`/`if`/`then`（blocked → feedback 非空の条件付き検証)を除去
- blocked の非空 feedback は review instruction 側の規律に委譲（feedback の description にも明記）
- contracts に「schema が strict モード非対応キーワード（allOf/anyOf/oneOf/if/then/else/not/$ref）を含まない」静的チェックを追加し、該当していた `expectInvalid`（blocked + 空 feedback）テストを削除

## 背景

codex provider は schema を OpenAI の `response_format` にそのまま渡すが、strict structured output は条件付き検証キーワードを許可しない。#97 で入った `allOf` により、schema を使う最初の step（preflight）が 400 (`invalid_json_schema`) になり #99 の takt run が即死した。#98 の `required` 修正と同根で、ローカル override が検証を偽装していた残件。

## 検証

- `bash scripts/check.sh contracts` → all checks passed（新設の strict 互換チェック込み）
- `bash scripts/check.sh shellcheck links` → all checks passed

関連: #97 / #98 / #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)