### PR TITLE
feat(nix): nh による Nix ストア週次自動クリーンを導入

### DIFF
--- a/config/.claude/skills/nix/SKILL.md
+++ b/config/.claude/skills/nix/SKILL.md
@@ -112,6 +112,31 @@ Nix > Homebrew > システム の順で PATH が構成されている。
 
 `which <command>` でどちらが使われているか確認できる。
 
+## ストア掃除（nh）
+
+Determinate Nix（`nix.enable = false`）のため nix-darwin の `nix.gc` /
+`nix.optimise` は使えない。代わりに [nh](https://github.com/nix-community/nh) を使う。
+
+- **自動**: root の launchd daemon `org.nixos.nh-clean` が毎週月曜 12:00 に
+  `nh clean all --keep 1 --keep-since 30d --optimise` を実行する
+  （`flake.nix` で定義。ログ: `/var/log/nh-clean.log`）
+- **手動で即掃除したい場合**:
+
+```bash
+# 削除対象の確認（dry-run）
+nh clean all --dry --keep 1 --keep-since 30d
+
+# 実行（システムプロファイルの世代削除には root が必要）
+sudo nh clean all --keep 1 --keep-since 30d --optimise
+```
+
+保持ポリシー: 直近 30 日の世代はすべて保持 + それ以前は最低 1 世代。
+`--keep-one` は「世代を 1 つ残す」ではなく「direnv プロジェクトごとに
+gcroot を最低 1 つ保持する」フラグなので注意（世代数は `--keep <N>`）。
+
+`programs.nh.flake` で `NH_FLAKE` が設定済みのため、`nh darwin switch` だけで
+`sudo darwin-rebuild switch --flake ~/01-dev/dotfiles` 相当の rebuild ができる。
+
 ## よくある操作の早見表
 
 | やりたいこと | 操作 |
@@ -123,3 +148,5 @@ Nix > Homebrew > システム の順で PATH が構成されている。
 | 全依存を最新化 | `nix flake update` → `darwin-rebuild switch` |
 | 現在のパッケージ一覧 | `nix/packages.nix` を読む |
 | ロールバック | `sudo darwin-rebuild switch --rollback` |
+| ストア掃除（dry-run） | `nh clean all --dry --keep 1 --keep-since 30d` |
+| ストア掃除（実行） | `sudo nh clean all --keep 1 --keep-since 30d --optimise` |

--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
 
           modules = [
             (
-              { lib, ... }:
+              { pkgs, lib, ... }:
               {
                 # Determinate Nix を使うため nix-daemon の管理を無効化
                 nix.enable = false;
@@ -117,6 +117,28 @@
                     "com.apple.finder" = {
                       ShowRecentTags = false;
                     };
+                  };
+                };
+
+                # ── Nix ストアの週次自動クリーン（nh） ──
+                # Determinate Nix（nix.enable = false）のため nix.gc / nix.optimise が
+                # 使えない。代わりに nh clean all を root の launchd daemon で週次実行し、
+                # 古い世代・orphan gcroot の削除とストアの重複排除を行う。
+                # 保持ポリシー: 直近 30 日の世代はすべて保持 + それ以前は最低 1 世代。
+                launchd.daemons.nh-clean = {
+                  command = "${pkgs.nh}/bin/nh clean all --keep 1 --keep-since 30d --optimise";
+                  serviceConfig = {
+                    # 月曜 12:00（スリープ中に時刻を跨ぐと launchd はその回を
+                    # スキップするため、稼働している可能性が高い日中に設定）
+                    StartCalendarInterval = [
+                      {
+                        Weekday = 1;
+                        Hour = 12;
+                        Minute = 0;
+                      }
+                    ];
+                    StandardOutPath = "/var/log/nh-clean.log";
+                    StandardErrorPath = "/var/log/nh-clean.err.log";
                   };
                 };
 

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -57,6 +57,17 @@ in
     ))
   ] ++ (hostConfig.extraPackages pkgs);
 
+  # ── nh: Nix ヘルパー CLI（GC root まで掃除できる clean コマンド持ち） ──
+  # 手動実行用: `nh clean all --dry` で削除対象を確認できる。
+  # NH_FLAKE を設定するので `nh darwin switch` だけで rebuild できる。
+  # 週次の自動クリーンは flake.nix 側の launchd daemon（root）で行う。
+  # useUserPackages = true のため世代は root 所有のシステムプロファイルに
+  # 積まれ、ユーザー権限の `nh clean user` では削除できないため。
+  programs.nh = {
+    enable = true;
+    flake = "${config.home.homeDirectory}/01-dev/dotfiles";
+  };
+
   # ── git 設定 ──
   programs.git = {
     enable = true;


### PR DESCRIPTION
## 概要

[Zenn 記事](https://zenn.dev/trifolium/articles/ed53f1a6ebbbf8) と [ryuryu333/dotfiles](https://github.com/ryuryu333/dotfiles) を参考に、nh による Nix ストアの自動クリーン（GC + 世代削除 + 重複排除）を導入する。

## 背景

- この dotfiles は Determinate Nix（`nix.enable = false`）のため、nix-darwin 標準の `nix.gc.automatic` / `nix.optimise` が使えない
- 標準の `nix-collect-garbage -d` は GC root（direnv の flake-profile 等）に繋がったパスを削除できない。nh は orphan gcroot の掃除まで行う（記事では 27GB → 4.6GB の実績）

## 変更内容

- **flake.nix**: `launchd.daemons.nh-clean` を追加。毎週月曜 12:00 に root で `nh clean all --keep 1 --keep-since 30d --optimise` を実行（ログ: `/var/log/nh-clean*.log`）
- **nix/packages.nix**: `programs.nh` を有効化（nh CLI の導入 + `NH_FLAKE` 設定により `nh darwin switch` で rebuild 可能に）
- **skills/nix**: nh の運用手順を追記

## 参考リポジトリからの意図的な差分

参考リポジトリは Home Manager の `programs.nh.clean` を使っているが、本リポジトリでは以下の理由で **nix-darwin 側の root daemon** にした:

1. `useUserPackages = true` のため世代は root 所有のシステムプロファイル（`/nix/var/nix/profiles/system-*-link`、現在 40 世代）に積まれ、ユーザー権限の `nh clean user` では削除できない
2. Home Manager の nh モジュールは darwin では `clean.extraArgs` を launchd の `ProgramArguments` に単一 argv として渡すため、複数フラグ指定がパースエラーで黙って失敗する

## 検証

- `darwin-rebuild build` 成功（両ホスト構成に適用される）
- 生成された plist（`org.nixos.nh-clean`）の引数分割・スケジュール・ログパスを確認
- `nh clean all --dry` 相当の dry-run で動作確認（削除済み worktree の orphan gcroot が検出された）

## 適用方法

マージ後、各マシンで:

```bash
sudo darwin-rebuild switch --flake ~/01-dev/dotfiles
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)