### PR TITLE
fix(zsh): hm-session-vars.sh を source して NH_FLAKE を有効化

### DIFF
--- a/config/.zshenv
+++ b/config/.zshenv
@@ -1,3 +1,8 @@
+# Home Manager のセッション変数（NH_FLAKE 等）
+# .zshrc は手動リンク管理のため HM は自動で source を挿入できない
+[ -f "/etc/profiles/per-user/$USER/etc/profile.d/hm-session-vars.sh" ] && \
+  . "/etc/profiles/per-user/$USER/etc/profile.d/hm-session-vars.sh"
+
 # Vite+ bin (https://viteplus.dev)
 [ -f "$HOME/.vite-plus/env" ] && . "$HOME/.vite-plus/env"
 


### PR DESCRIPTION
## 概要

PR #105 の適用後検証で、`NH_FLAKE` が shell に反映されていないことが判明した。

## 原因

この dotfiles は `.zshrc` / `.zshenv` を `home.activation.linkDotfiles` の手動リンクで管理しているため、Home Manager が `home.sessionVariables`（`programs.nh.flake` が設定する `NH_FLAKE` を含む）を shell に注入する経路が存在しなかった。変数は `/etc/profiles/per-user/$USER/etc/profile.d/hm-session-vars.sh` に生成されているが、どこからも source されていなかった。

## 修正

`.zshenv` の先頭で `hm-session-vars.sh` を source する（存在チェック付き・冪等ガードは HM 側にあり）。

## 検証

```
$ zsh -c '. /etc/profiles/per-user/mba/etc/profile.d/hm-session-vars.sh; echo $NH_FLAKE'
/Users/mba/01-dev/dotfiles
```

これにより `nh darwin switch` が引数なしで動くようになる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)