### PR TITLE
[#104] issue-104-kasutamu-workflow-no

### DIFF
--- a/config/.claude/skills/takt/references/workflows.md
+++ b/config/.claude/skills/takt/references/workflows.md
@@ -25,6 +25,17 @@ feature / improve / diagnose-fix / docs / lite / solid は、先頭の `prefligh
 
 同じ 6 workflow の review（diagnose-fix は supervise）は、daemon 不達・ネットワーク・権限などコード変更では解消できない環境障害で受け入れ基準を検証できない場合、`needs_fix` ではなく `blocked` を返して **ABORT** する。通常の実装不備・記述不備などコード変更で解消可能な失敗は `needs_fix` の既存帰路を使う。
 
+## implement で nix 系ゲートを実行するための Codex sandbox 設定
+
+カスタム workflow の codex provider には `network_access: true` を設定している。これは nix daemon を含む Unix socket 接続とネットワークを許可するが、nix の fetcher cache を書き込む権限は別途必要になる。implement の workspace-write sandbox で `nix-eval` などの nix 依存ゲートを実行するマシンでは、`~/.codex/config.toml` に次を設定する。
+
+```toml
+[sandbox_workspace_write]
+writable_roots = ["/Users/mba/.cache/nix"]
+```
+
+`writable_roots` は workspace-write sandbox 専用で、review など read-only の step には適用されない。未設定のマシンでは nix 系ゲートが fail するため、CI 委譲の表記に従って検証する。
+
 ## 目次
 
 - [feature（新規開発・custom）](#feature-新規開発custom)

--- a/config/.takt/workflows/docs.yaml
+++ b/config/.takt/workflows/docs.yaml
@@ -11,6 +11,10 @@
 #   structured_output + `when:` で Phase 3 を完全にスキップ、全 step provider: codex を明示）
 name: docs
 description: ドキュメント・skill 改善用の最軽量 workflow（preflight → 実装 → 整合実証レビューの 3 step）。コード変更を伴うタスクは lite / improve を使う
+workflow_config:
+  provider_options:
+    codex:
+      network_access: true
 max_steps: 9
 initial_step: preflight
 steps:

--- a/config/.takt/workflows/improve.yaml
+++ b/config/.takt/workflows/improve.yaml
@@ -16,6 +16,10 @@
 #   structured_output + `when:` で Phase 3 を完全にスキップ、全 step provider: codex を明示）
 name: improve
 description: 機能改善（既存機能の挙動変更・拡張）用 workflow。挙動変更影響表で意図した変更と回帰を区別する。interface 変更を伴う場合は feature を使う
+workflow_config:
+  provider_options:
+    codex:
+      network_access: true
 max_steps: 12
 initial_step: preflight
 steps:

--- a/config/.takt/workflows/lite.yaml
+++ b/config/.takt/workflows/lite.yaml
@@ -14,6 +14,10 @@
 # - 全 step provider: codex を明示（02-yt と挙動・トークン特性を揃える意図的な選択。
 #   グローバル config のハイブリッド方針（レビュー系 = Claude）はこの workflow には適用しない）
 name: lite
+workflow_config:
+  provider_options:
+    codex:
+      network_access: true
 max_steps: 12
 initial_step: preflight
 loop_monitors:

--- a/config/.takt/workflows/solid.yaml
+++ b/config/.takt/workflows/solid.yaml
@@ -19,6 +19,10 @@
 # - 全 step provider: codex を明示（lite と挙動・トークン特性を揃える）
 name: solid
 description: lite の一段上の堅牢版。lite で完了できなかった task の再走が主用途（preflight → 失敗原因分析 → 再計画 → ゼロから再実装 → レビュー）。スコープ過大なら分割提案を出して停止
+workflow_config:
+  provider_options:
+    codex:
+      network_access: true
 max_steps: 18
 initial_step: preflight
 loop_monitors:

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -281,6 +281,38 @@ check_contracts() {
     local hermetic_home
     hermetic_home="$(mktemp -d)"
     ln -s "$REPO_ROOT/config/.takt" "$hermetic_home/.takt"
+
+    echo "-- checking codex network access reaches every workflow step --"
+    local network_workflow
+    for network_workflow in lite feature improve solid docs diagnose-fix fix; do
+      if ! HOME="$hermetic_home" \
+        WORKFLOW_FILE="$workflows_dir/$network_workflow.yaml" \
+        TAKT_ROOT="$takt_root" WORKFLOW_NAME="$network_workflow" \
+        node --input-type=module <<'NODE'
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const importTakt = async (relativePath) => import(pathToFileURL(join(process.env.TAKT_ROOT, relativePath)).href);
+const { loadWorkflowFromFile } = await importTakt('dist/infra/config/loaders/workflowFileLoader.js');
+const workflow = loadWorkflowFromFile(process.env.WORKFLOW_FILE, process.cwd());
+const workflowName = process.env.WORKFLOW_NAME;
+
+if (workflow.providerOptions?.codex?.networkAccess !== true) {
+  throw new Error(`${workflowName}: workflow codex.networkAccess is not true after loading`);
+}
+for (const step of workflow.steps.filter(({ provider }) => provider === 'codex')) {
+  if (step.workflowProviderOptions?.codex?.networkAccess !== true
+      || step.providerOptions?.codex?.networkAccess !== true) {
+    throw new Error(`${workflowName}/${step.name}: codex.networkAccess does not reach the execution options`);
+  }
+}
+NODE
+      then
+        echo "INVALID: $network_workflow does not load codex network_access into its steps" >&2
+        status=1
+      fi
+    done
+
     local workflow expected_next
     for workflow in feature improve diagnose-fix docs lite solid; do
       case "$workflow" in


### PR DESCRIPTION
## Summary

## 概要

カスタム workflow の codex provider に `network_access: true` を設定し、implement 系 step（workspace-write sandbox）から nix daemon・ネットワーク依存の品質ゲート（`nix-eval`、`pnpm install --frozen-lockfile` 等）を検証可能にする。あわせて、nix の fetcher-cache に必要な `~/.codex/config.toml` の `writable_roots` 設定手順を takt skill のドキュメントに記載する。

## 背景・目的

codex sandbox（seatbelt）では unix domain socket への接続が network 規則で拒否されるため、nix daemon に依存するゲートが agent から実行できなかった。検証実験の結果:

| workspace-write の設定 | `bash scripts/check.sh nix-eval` |
|---|---|
| 素のまま | ❌ daemon socket 接続拒否（Operation not permitted） |
| `writable_roots` のみ | ❌ 同上（socket はファイル規則でなく network 規則の管轄） |
| `network_access=true` のみ | ⚠️ socket は通るが `~/.cache/nix/fetcher-cache-v4.sqlite` が開けず fail |
| `network_access=true` + `writable_roots=["~/.cache/nix"]` | ✅ exit 0（all checks passed） |

`network_access` は takt が `workflow_config.provider_options.codex.network_access` として workflow yaml から渡せる（builtin default は設定済みで、カスタム workflow だけが未設定）。`writable_roots` は takt の SDK オプションに存在しないため、`~/.codex/config.toml` の `[sandbox_workspace_write]` で設定するしかない（codex config は dotfiles 管理外のため手順の文書化で対応する）。

これにより implement step は nix / network 系ゲートをローカル検証できるようになる。review 等の edit:false step は read-only sandbox のまま（`writable_roots` は workspace-write 専用設定）なので、reviewer の検証は #102 の CI 委譲運用を維持する。

## 提案する仕様

1. カスタム workflow に以下を追加する（builtin default と同じ形式）:

   ```yaml
   workflow_config:
     provider_options:
       codex:
         network_access: true
   ```

2. takt skill の参照ドキュメントに、nix 依存ゲートを implement で検証するための `~/.codex/config.toml` 設定手順を記載する:

   ```toml
   [sandbox_workspace_write]
   writable_roots = ["/Users/mba/.cache/nix"]
   ```

   あわせて「network_access は socket 接続（nix daemon 含む）を許可する」「writable_roots 未設定のマシンでは nix 系ゲートは fail するので CI 委譲表記に従う」を明記する。

## ユースケース

- dotfiles の issue で受け入れ基準に `nix-eval` がある場合、implement（coder）が sandbox 内で `bash scripts/check.sh nix-eval` を実行して自己検証できる
- 00-automation の extensions 系 issue（例: Fallow 導入）で、implement が `pnpm install --frozen-lockfile` / `pnpm run audit` を sandbox 内で実行できる（従来は daemon / network 拒否で fix ループ空回りの原因だった）

## 参照資料

- config/.takt/workflows/lite.yaml
- config/.takt/workflows/feature.yaml
- config/.takt/workflows/improve.yaml
- config/.takt/workflows/solid.yaml
- config/.takt/workflows/docs.yaml
- config/.takt/workflows/diagnose-fix.yaml
- config/.takt/workflows/fix.yaml
- config/.claude/skills/takt/references/workflows.md
- ~/.bun/install/global/node_modules/takt/builtins/ja/workflows/default.yaml（workflow_config.provider_options の参照実装）

## 影響ファイル

- **変更**: config/.takt/workflows/lite.yaml
- **変更**: config/.takt/workflows/feature.yaml
- **変更**: config/.takt/workflows/improve.yaml
- **変更**: config/.takt/workflows/solid.yaml
- **変更**: config/.takt/workflows/docs.yaml
- **変更**: config/.takt/workflows/diagnose-fix.yaml
- **変更**: config/.takt/workflows/fix.yaml
- **変更**: config/.claude/skills/takt/references/workflows.md

**兄弟入口・貫通先**:

- 7 つのカスタム workflow すべてが対象（e2e-verify.yaml は browser 操作前提で既に network が必要な場合は同時に確認して揃える）
- 00-automation 等の利用リポジトリは共有 workflow（~/.takt/workflows symlink）経由で自動反映のため変更不要
- `~/.codex/config.toml` は dotfiles 管理外のため、コード変更ではなくドキュメント（workflows.md）での手順記載とする

## 要件

1. 7 つのカスタム workflow（lite / feature / improve / solid / docs / diagnose-fix / fix）に `workflow_config.provider_options.codex.network_access: true` を追加する → implement 系 step の sandbox で unix socket 接続とネットワークが許可される
2. `takt workflow doctor` が全 7 workflow で exit 0 になる → 設定追加後もロード可能
3. workflows.md に `writable_roots` の設定手順と制約（workspace-write 専用・review は read-only のため CI 委譲を維持）を記載する → nix 系ゲートを implement で検証する前提条件が文書化される

## スコープ外

- review 等の edit:false step の sandbox 緩和（read-only → workspace-write 化）は扱わない（reviewer への書き込み権限付与は別途の設計判断。CI 委譲運用 #102 を維持）
- `~/.codex/config.toml` 自体の dotfiles 管理化は扱わない
- takt 本体（nrslib/takt）への writable_roots オプション追加の提案は扱わない
- 00-automation 側のリポジトリ変更は扱わない（共有 workflow 経由で自動反映）

## 受け入れ基準

- [ ] `bash scripts/check.sh shellcheck links contracts` が exit 0 になる
- [ ] `takt workflow doctor config/.takt/workflows/<name>.yaml` が 7 workflow すべてで exit 0 になる
- [ ] CI の nix-eval job が pass する

## 実装方針（takt）

- workflow: lite
- 理由: yaml への宣言追加とドキュメント追記のみでコード変更がなく、doctor / contracts チェックで回帰確認できるため

## Execution Report

Workflow `lite` completed successfully.

Closes #104